### PR TITLE
Add truncateZeroTimeInDates option for date serialization

### DIFF
--- a/src/__tests__/date-format-precision.test.ts
+++ b/src/__tests__/date-format-precision.test.ts
@@ -125,4 +125,14 @@ describe('DateFormatHelper.createDateWithOriginalFormat millisecond precision', 
     expect(result instanceof LocalDate).toBe(true);
     expect(result.toISOString()).toBe('2024-01-16');
   });
+
+  test('should keep time component when creating from Date with zero time components, but raw string has time component', () => {
+    const originalDate = new Date('2024-01-15T00:00:00.000Z');
+    const newDateNoTime = new Date('2024-01-16T00:00:00.000Z'); // No time components
+    
+    const result = DateFormatHelper.createDateWithOriginalFormat(newDateNoTime, '2024-01-16T00:00:00.000Z');
+    
+    expect(result.toISOString()).toBe('2024-01-16T00:00:00.000Z');
+  });
+
 });

--- a/src/__tests__/date-format-precision.test.ts
+++ b/src/__tests__/date-format-precision.test.ts
@@ -4,107 +4,92 @@ describe('DateFormatHelper.createDateWithOriginalFormat millisecond precision', 
   
   test('should preserve millisecond precision for LocalTime', () => {
     // Test with 1 digit millisecond precision
-    const originalTime1 = new Date('1970-01-01T10:30:00.500Z');
-    const newTime1 = new Date('1970-01-01T14:15:00.123Z');
-    const result1 = DateFormatHelper.createDateWithOriginalFormat(newTime1, '10:30:00.5');
+    const time1 = new Date('1970-01-01T14:15:00.123Z');
+    const result1 = DateFormatHelper.createDateWithOriginalFormat(time1, '10:30:00.5');
     expect(result1.toISOString()).toBe('14:15:00.1');
     
     // Test with 3 digit millisecond precision
-    const originalTime3 = new Date('1970-01-01T10:30:00.500Z');
-    const newTime3 = new Date('1970-01-01T14:15:00.123Z');
-    const result3 = DateFormatHelper.createDateWithOriginalFormat(newTime3, '10:30:00.500');
+    const time3 = new Date('1970-01-01T14:15:00.123Z');
+    const result3 = DateFormatHelper.createDateWithOriginalFormat(time3, '10:30:00.500');
     expect(result3.toISOString()).toBe('14:15:00.123');
     
     // Test without milliseconds in original but with milliseconds in new value - should include them
-    const originalTimeNoMs = new Date('1970-01-01T10:30:00.000Z');
-    const newTimeWithMs = new Date('1970-01-01T14:15:00.123Z');
-    const resultNoMs = DateFormatHelper.createDateWithOriginalFormat(newTimeWithMs, '10:30:00');
+    const timeWithMs = new Date('1970-01-01T14:15:00.123Z');
+    const resultNoMs = DateFormatHelper.createDateWithOriginalFormat(timeWithMs, '10:30:00');
     expect(resultNoMs.toISOString()).toBe('14:15:00.123');
   });
 
   test('should preserve millisecond precision for LocalDateTime with T separator', () => {
     // Test with milliseconds
-    const originalDateTime = new Date('2024-01-15T10:30:00.500Z');
-    const newDateTime = new Date('2024-02-20T14:15:00.123Z');
-    const result = DateFormatHelper.createDateWithOriginalFormat(newDateTime, '2024-01-15T10:30:00.500');
+    const dateTime = new Date('2024-02-20T14:15:00.123Z');
+    const result = DateFormatHelper.createDateWithOriginalFormat(dateTime, '2024-01-15T10:30:00.500');
     expect(result.toISOString()).toBe('2024-02-20T14:15:00.123');
     
     // Test without milliseconds in original but with milliseconds in new value - should include them
-    const originalDateTimeNoMs = new Date('2024-01-15T10:30:00.000Z');
-    const newDateTimeWithMs = new Date('2024-02-20T14:15:00.123Z');
-    const resultNoMs = DateFormatHelper.createDateWithOriginalFormat(newDateTimeWithMs, '2024-01-15T10:30:00');
+    const dateTimeWithMs = new Date('2024-02-20T14:15:00.123Z');
+    const resultNoMs = DateFormatHelper.createDateWithOriginalFormat(dateTimeWithMs, '2024-01-15T10:30:00');
     expect(resultNoMs.toISOString()).toBe('2024-02-20T14:15:00.123');
   });
 
   test('should preserve millisecond precision for LocalDateTime with space separator', () => {
     // Test with milliseconds
-    const originalDateTime = new Date('2024-01-15T10:30:00.500Z');
-    const newDateTime = new Date('2024-02-20T14:15:00.123Z');
-    const result = DateFormatHelper.createDateWithOriginalFormat(newDateTime, '2024-01-15 10:30:00.500');
+    const dateTime = new Date('2024-02-20T14:15:00.123Z');
+    const result = DateFormatHelper.createDateWithOriginalFormat(dateTime, '2024-01-15 10:30:00.500');
     expect(result.toISOString()).toBe('2024-02-20 14:15:00.123');
     
     // Test without milliseconds in original but with milliseconds in new value - should include them
-    const originalDateTimeNoMs = new Date('2024-01-15T10:30:00.000Z');
-    const newDateTimeWithMs = new Date('2024-02-20T14:15:00.123Z');
-    const resultNoMs = DateFormatHelper.createDateWithOriginalFormat(newDateTimeWithMs, '2024-01-15 10:30:00');
+    const dateTimeWithMs = new Date('2024-02-20T14:15:00.123Z');
+    const resultNoMs = DateFormatHelper.createDateWithOriginalFormat(dateTimeWithMs, '2024-01-15 10:30:00');
     expect(resultNoMs.toISOString()).toBe('2024-02-20 14:15:00.123');
   });
 
   test('should preserve millisecond precision for OffsetDateTime', () => {
     // Test with milliseconds and Z offset
-    const originalOffset = new Date('2024-01-15T10:30:00.500Z');
-    const newOffset = new Date('2024-02-20T14:15:00.123Z');
-    const result = DateFormatHelper.createDateWithOriginalFormat(newOffset, '2024-01-15T10:30:00.500Z');
+    const offset = new Date('2024-02-20T14:15:00.123Z');
+    const result = DateFormatHelper.createDateWithOriginalFormat(offset, '2024-01-15T10:30:00.500Z');
     expect(result.toISOString()).toBe('2024-02-20T14:15:00.123Z');
     
     // Test without milliseconds in original but with milliseconds in new value - should include them
-    const originalOffsetNoMs = new Date('2024-01-15T10:30:00Z');
-    const newOffsetWithMs = new Date('2024-02-20T14:15:00.123Z');
-    const resultOffsetNoMs = DateFormatHelper.createDateWithOriginalFormat(newOffsetWithMs, '2024-01-15T10:30:00Z');
+    const offsetWithMs = new Date('2024-02-20T14:15:00.123Z');
+    const resultOffsetNoMs = DateFormatHelper.createDateWithOriginalFormat(offsetWithMs, '2024-01-15T10:30:00Z');
     expect(resultOffsetNoMs.toISOString()).toBe('2024-02-20T14:15:00.123Z');
   });
 
   test('should handle different millisecond digit counts', () => {
     // Test 1 digit
-    const original1 = new Date('1970-01-01T10:30:00.500Z');
-    const new1 = new Date('1970-01-01T14:15:00.789Z');
-    const result1 = DateFormatHelper.createDateWithOriginalFormat(new1, '10:30:00.5');
+    const time1 = new Date('1970-01-01T14:15:00.789Z');
+    const result1 = DateFormatHelper.createDateWithOriginalFormat(time1, '10:30:00.5');
     expect(result1.toISOString()).toBe('14:15:00.7');
     
     // Test 2 digits
-    const original2 = new Date('1970-01-01T10:30:00.500Z');
-    const new2 = new Date('1970-01-01T14:15:00.789Z');
-    const result2 = DateFormatHelper.createDateWithOriginalFormat(new2, '10:30:00.50');
+    const time2 = new Date('1970-01-01T14:15:00.789Z');
+    const result2 = DateFormatHelper.createDateWithOriginalFormat(time2, '10:30:00.50');
     expect(result2.toISOString()).toBe('14:15:00.78');
     
     // Test 3 digits
-    const original3 = new Date('1970-01-01T10:30:00.500Z');
-    const new3 = new Date('1970-01-01T14:15:00.789Z');
-    const result3 = DateFormatHelper.createDateWithOriginalFormat(new3, '10:30:00.500');
+    const time3 = new Date('1970-01-01T14:15:00.789Z');
+    const result3 = DateFormatHelper.createDateWithOriginalFormat(time3, '10:30:00.500');
     expect(result3.toISOString()).toBe('14:15:00.789');
   });
 
   test('should handle zero milliseconds correctly', () => {
     // When original has milliseconds but new date has zero milliseconds
-    const originalMs = new Date('1970-01-01T10:30:00.500Z');
-    const newNoMs = new Date('1970-01-01T14:15:00.000Z');
-    const result = DateFormatHelper.createDateWithOriginalFormat(newNoMs, '10:30:00.500');
+    const timeNoMs = new Date('1970-01-01T14:15:00.000Z');
+    const result = DateFormatHelper.createDateWithOriginalFormat(timeNoMs, '10:30:00.500');
     // Should preserve millisecond format even when zero
     expect(result.toISOString()).toBe('14:15:00.000');
     
     // When original has no milliseconds and new date has zero milliseconds
-    const originalNoMs = new Date('1970-01-01T10:30:00.000Z');
-    const newNoMs2 = new Date('1970-01-01T14:15:00.000Z');
-    const resultNoMs = DateFormatHelper.createDateWithOriginalFormat(newNoMs2, '10:30:00');
+    const timeNoMs2 = new Date('1970-01-01T14:15:00.000Z');
+    const resultNoMs = DateFormatHelper.createDateWithOriginalFormat(timeNoMs2, '10:30:00');
     expect(resultNoMs.toISOString()).toBe('14:15:00');
   });
 
   test('should upgrade LocalDate to LocalDateTime when Date has time components', () => {
     // Test that attempting to set a date-only field with time components upgrades to LocalDateTime
-    const originalDate = new Date('2024-01-15T00:00:00.000Z');
-    const newDateWithTime = new Date('2024-01-16T10:30:45.123Z'); // Has time components
+    const dateWithTime = new Date('2024-01-16T10:30:45.123Z'); // Has time components
     
-    const result = DateFormatHelper.createDateWithOriginalFormat(newDateWithTime, '2024-01-15');
+    const result = DateFormatHelper.createDateWithOriginalFormat(dateWithTime, '2024-01-15');
     
     // Should be upgraded to LocalDateTime (with T separator)
     expect(result instanceof LocalDateTime).toBe(true);
@@ -116,10 +101,9 @@ describe('DateFormatHelper.createDateWithOriginalFormat millisecond precision', 
 
   test('should keep LocalDate when creating from Date with zero time components', () => {
     // Test that creating a LocalDate from a Date with all zero time components stays as LocalDate
-    const originalDate = new Date('2024-01-15T00:00:00.000Z');
-    const newDateNoTime = new Date('2024-01-16T00:00:00.000Z'); // No time components
+    const dateNoTime = new Date('2024-01-16T00:00:00.000Z'); // No time components
     
-    const result = DateFormatHelper.createDateWithOriginalFormat(newDateNoTime, '2024-01-15');
+    const result = DateFormatHelper.createDateWithOriginalFormat(dateNoTime, '2024-01-15');
     
     // Should remain a LocalDate
     expect(result instanceof LocalDate).toBe(true);
@@ -127,10 +111,9 @@ describe('DateFormatHelper.createDateWithOriginalFormat millisecond precision', 
   });
 
   test('should keep time component when creating from Date with zero time components, but raw string has time component', () => {
-    const originalDate = new Date('2024-01-15T00:00:00.000Z');
-    const newDateNoTime = new Date('2024-01-16T00:00:00.000Z'); // No time components
+    const dateNoTime = new Date('2024-01-16T00:00:00.000Z'); // No time components
     
-    const result = DateFormatHelper.createDateWithOriginalFormat(newDateNoTime, '2024-01-16T00:00:00.000Z');
+    const result = DateFormatHelper.createDateWithOriginalFormat(dateNoTime, '2024-01-16T00:00:00.000Z');
     
     expect(result.toISOString()).toBe('2024-01-16T00:00:00.000Z');
   });

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -1665,3 +1665,190 @@ test('should preserve datetime format when patching to zero time component', () 
     event_name = "Workshop"
     ` + '\n');
 });
+
+test('should not affect time-only values with truncateZeroTimeInDates option (non-zero time)', () => {
+  // Test that truncateZeroTimeInDates doesn't affect LocalTime values (time-only, no date component)
+  const existing = dedent`
+    meeting_time = 14:30:00
+    event_name = "Team Meeting"
+    ` + '\n';
+
+  const value = parse(existing);
+  
+  // Change to a different time
+  const meetingTime = value.meeting_time as Date;
+  const newMeetingTime = new Date(meetingTime.getTime() + 2 * 60 * 60 * 1000); // Add 2 hours
+  value.meeting_time = newMeetingTime;
+
+  const patched = patch(existing, value, { truncateZeroTimeInDates: true });
+
+  // The result should show the time as-is, not affected by truncateZeroTimeInDates
+  expect(patched).toEqual(dedent`
+    meeting_time = 16:30:00
+    event_name = "Team Meeting"
+    ` + '\n');
+});
+
+test('should not affect time-only values with truncateZeroTimeInDates option (zero time)', () => {
+  // Test that truncateZeroTimeInDates doesn't affect LocalTime values even when time is 00:00:00
+  const existing = dedent`
+    start_time = 23:00:00
+    event_name = "Late Event"
+    ` + '\n';
+
+  const value = parse(existing);
+  
+  // Change to midnight (00:00:00)
+  const startTime = value.start_time as Date;
+  const newStartTime = new Date(startTime.getTime() + 1 * 60 * 60 * 1000); // Add 1 hour to get 00:00:00
+  value.start_time = newStartTime;
+
+  const patched = patch(existing, value, { truncateZeroTimeInDates: true });
+
+  // The result should show 00:00:00 as-is, not be truncated or affected
+  expect(patched).toEqual(dedent`
+    start_time = 00:00:00
+    event_name = "Late Event"
+    ` + '\n');
+});
+
+test('should preserve time component for offset datetime even when UTC equivalent is zero time', () => {
+  // Test that an OffsetDateTime with non-zero local time but zero UTC time
+  // keeps its time component with truncateZeroTimeInDates: true
+  // Example: 2024-01-15T02:00:00+02:00 = 2024-01-15T00:00:00Z in UTC
+  const existing = dedent`
+    event_start = 2024-01-15T02:00:00+02:00
+    event_name = "Morning Event"
+    ` + '\n';
+
+  const value = parse(existing);
+  
+  // Change to a different date, also with time that is zero in UTC but non-zero locally
+  // We add 36 days, which keeps the same local time with the offset
+  const eventStart = value.event_start as Date;
+  const newEventStart = new Date(eventStart.getTime() + 36 * 24 * 60 * 60 * 1000); // Add 36 days
+  value.event_start = newEventStart;
+
+  const patched = patch(existing, value, { truncateZeroTimeInDates: true });
+
+  // The result should keep the time component because the local time is 02:00:00, not 00:00:00
+  // Even though in UTC it's 00:00:00, the local time has a non-zero component
+  expect(patched).toEqual(dedent`
+    event_start = 2024-02-20T02:00:00+02:00
+    event_name = "Morning Event"
+    ` + '\n');
+});
+
+test('should preserve time component for local datetime with non-zero time and truncateZeroTimeInDates', () => {
+  // Test that a LocalDateTime (no timezone) with non-zero time keeps its time component
+  const existing = dedent`
+    event_start = 2024-01-15T14:30:00
+    event_name = "Afternoon Meeting"
+    ` + '\n';
+
+  const value = parse(existing);
+  
+  // Change to a different date with same time
+  const eventStart = value.event_start as Date;
+  const newEventStart = new Date(eventStart.getTime() + 36 * 24 * 60 * 60 * 1000); // Add 36 days
+  value.event_start = newEventStart;
+
+  const patched = patch(existing, value, { truncateZeroTimeInDates: true });
+
+  // The result should keep the time component
+  expect(patched).toEqual(dedent`
+    event_start = 2024-02-20T14:30:00
+    event_name = "Afternoon Meeting"
+    ` + '\n');
+});
+
+test('should preserve datetime format for local datetime with zero time component', () => {
+  // Test that a LocalDateTime with T00:00:00 preserves the time component
+  // even with truncateZeroTimeInDates: true, because the original format has time
+  const existing = dedent`
+    event_start = 2024-01-15T00:00:00
+    event_name = "Midnight Event"
+    ` + '\n';
+
+  const value = parse(existing);
+  
+  // Change to a different date, also with zero time
+  const eventStart = value.event_start as Date;
+  const newEventStart = new Date(eventStart.getTime() + 36 * 24 * 60 * 60 * 1000); // Add 36 days
+  value.event_start = newEventStart;
+
+  const patched = patch(existing, value, { truncateZeroTimeInDates: true });
+
+  // The result should keep T00:00:00 because the original format has time component
+  // truncateZeroTimeInDates should not affect values from existing TOML
+  expect(patched).toEqual(dedent`
+    event_start = 2024-02-20T00:00:00
+    event_name = "Midnight Event"
+    ` + '\n');
+});
+
+test('should add new date with zero time as date-only when truncateZeroTimeInDates is true', () => {
+  // Test adding a new date key-value that wasn't in the original TOML
+  const existing = dedent`
+    event_name = "Conference"
+    location = "Seattle"
+    ` + '\n';
+
+  const value = parse(existing);
+  
+  // Add a new date with zero time components
+  value.event_date = new Date('2024-01-15T00:00:00.000Z');
+
+  const patched = patch(existing, value, { truncateZeroTimeInDates: true });
+
+  // The new date should be added as date-only (no time component)
+  expect(patched).toEqual(dedent`
+    event_name = "Conference"
+    location = "Seattle"
+    event_date = 2024-01-15
+    ` + '\n');
+});
+
+test('should add new date with zero time as full timestamp when truncateZeroTimeInDates is false (default)', () => {
+  // Test adding a new date key-value with default behavior (truncateZeroTimeInDates: false)
+  const existing = dedent`
+    event_name = "Workshop"
+    location = "Portland"
+    ` + '\n';
+
+  const value = parse(existing);
+  
+  // Add a new date with zero time components
+  value.event_date = new Date('2024-01-15T00:00:00.000Z');
+
+  const patched = patch(existing, value);
+
+  // The new date should be added with full timestamp
+  expect(patched).toEqual(dedent`
+    event_name = "Workshop"
+    location = "Portland"
+    event_date = 2024-01-15T00:00:00.000Z
+    ` + '\n');
+});
+
+test('should add new date with non-zero time as full timestamp regardless of truncateZeroTimeInDates', () => {
+  // Test that non-zero time is always preserved
+  const existing = dedent`
+    event_name = "Meetup"
+    location = "Austin"
+    ` + '\n';
+
+  const value = parse(existing);
+  
+  // Add a new date with non-zero time components
+  value.event_datetime = new Date('2024-01-15T14:30:00.000Z');
+
+  const patched = patch(existing, value, { truncateZeroTimeInDates: true });
+
+  // The new date should be added with full timestamp since time is non-zero
+  expect(patched).toEqual(dedent`
+    event_name = "Meetup"
+    location = "Austin"
+    event_datetime = 2024-01-15T14:30:00.000Z
+    ` + '\n');
+});

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -1620,3 +1620,48 @@ test('should patch local time values while preserving format', () => {
     active = true
     ` + '\n');
 });
+
+test('should preserve zero time component when patching date with zero time', () => {
+  // Test that when the original TOML has a date with time component at zero,
+  // and we patch it to a new date, the time component is preserved
+  const existing = dedent`
+    event_start = 2024-01-15T00:00:00.000Z
+    event_name = "Conference"
+    ` + '\n';
+
+  const value = parse(existing);
+  
+  // Change to a different date, also with zero time components
+  value.event_start = new Date('2024-02-20T00:00:00.000Z');
+
+  const patched = patch(existing, value);
+
+  // The result should keep the time component (not truncate to date-only)
+  expect(patched).toEqual(dedent`
+    event_start = 2024-02-20T00:00:00.000Z
+    event_name = "Conference"
+    ` + '\n');
+});
+
+test('should preserve datetime format when patching to zero time component', () => {
+  // Test that when the original TOML has a date with non-zero time component,
+  // and we patch it to a date with zero time components,
+  // the resulting TOML shows the zero-time component (not just the date)
+  const existing = dedent`
+    event_start = 2024-01-15T10:30:45.000Z
+    event_name = "Workshop"
+    ` + '\n';
+
+  const value = parse(existing);
+  
+  // Change to a date with zero time components
+  value.event_start = new Date('2024-02-20T00:00:00.000Z');
+
+  const patched = patch(existing, value);
+
+  // The result should show the full timestamp with zero time, not just the date
+  expect(patched).toEqual(dedent`
+    event_start = 2024-02-20T00:00:00.000Z
+    event_name = "Workshop"
+    ` + '\n');
+});

--- a/src/__tests__/stringify.test.ts
+++ b/src/__tests__/stringify.test.ts
@@ -445,3 +445,47 @@ test('should respect inlineTableStart=2 setting for deeper nesting', () => {
   expect(resultLevel1).toEqual(expectedLevel1);
 });
 
+test('should stringify date with T00:00:00.000Z without time information when truncateZeroTimeInDates is true', () => {
+  // Create a Date object with zero time components
+  const dateWithZeroTime = new Date('2024-01-15T00:00:00.000Z');
+  
+  const jsObject = {
+    project: "TestProject",
+    created_date: dateWithZeroTime,
+    version: "1.0.0"
+  };
+
+  const result = stringify(jsObject, { truncateZeroTimeInDates: true });
+
+  // The date should be output as date-only (no time component)
+  const expected = dedent`
+    project = "TestProject"
+    created_date = 2024-01-15
+    version = "1.0.0"
+    ` + '\n';
+
+  expect(result).toEqual(expected);
+});
+
+test('should stringify date with T00:00:00.000Z with time information when truncateZeroTimeInDates is false (default)', () => {
+  // Create a Date object with zero time components
+  const dateWithZeroTime = new Date('2024-01-15T00:00:00.000Z');
+  
+  const jsObject = {
+    project: "TestProject",
+    created_date: dateWithZeroTime,
+    version: "1.0.0"
+  };
+
+  const result = stringify(jsObject);
+
+  // The date should be output with full time information
+  const expected = dedent`
+    project = "TestProject"
+    created_date = 2024-01-15T00:00:00.000Z
+    version = "1.0.0"
+    ` + '\n';
+
+  expect(result).toEqual(expected);
+});
+

--- a/src/__tests__/stringify.test.ts
+++ b/src/__tests__/stringify.test.ts
@@ -489,3 +489,149 @@ test('should stringify date with T00:00:00.000Z with time information when trunc
   expect(result).toEqual(expected);
 });
 
+test('should handle arrays of dates with mixed zero and non-zero times when truncateZeroTimeInDates is true', () => {
+  const jsObject = {
+    project: "TestProject",
+    event_dates: [
+      new Date('2024-01-15T00:00:00.000Z'), // Zero time - should be truncated
+      new Date('2024-02-20T14:30:00.000Z'), // Non-zero time - should keep time
+      new Date('2024-03-10T00:00:00.000Z'), // Zero time - should be truncated
+    ]
+  };
+
+  const result = stringify(jsObject, { truncateZeroTimeInDates: true });
+
+  const expected = dedent`
+    project = "TestProject"
+    event_dates = [ 2024-01-15, 2024-02-20T14:30:00.000Z, 2024-03-10 ]
+    ` + '\n';
+
+  expect(result).toEqual(expected);
+});
+
+test('should handle arrays of dates without truncation when truncateZeroTimeInDates is false', () => {
+  const jsObject = {
+    project: "TestProject",
+    event_dates: [
+      new Date('2024-01-15T00:00:00.000Z'),
+      new Date('2024-02-20T14:30:00.000Z'),
+      new Date('2024-03-10T00:00:00.000Z'),
+    ]
+  };
+
+  const result = stringify(jsObject, { truncateZeroTimeInDates: false });
+
+  const expected = dedent`
+    project = "TestProject"
+    event_dates = [ 2024-01-15T00:00:00.000Z, 2024-02-20T14:30:00.000Z, 2024-03-10T00:00:00.000Z ]
+    ` + '\n';
+
+  expect(result).toEqual(expected);
+});
+
+test('should handle dates in nested objects with truncateZeroTimeInDates is true', () => {
+  const jsObject = {
+    project: {
+      name: "MyProject",
+      created: new Date('2024-01-15T00:00:00.000Z'), // Zero time - should be truncated
+      metadata: {
+        last_updated: new Date('2024-02-20T14:30:00.000Z'), // Non-zero time - should keep time
+        start_date: new Date('2024-03-10T00:00:00.000Z'), // Zero time - should be truncated
+      }
+    }
+  };
+
+  const result = stringify(jsObject, { truncateZeroTimeInDates: true });
+
+  const expected = dedent`
+    [project]
+    name = "MyProject"
+    created = 2024-01-15
+    metadata = { last_updated = 2024-02-20T14:30:00.000Z, start_date = 2024-03-10 }
+    ` + '\n';
+
+  expect(result).toEqual(expected);
+});
+
+test('should handle dates in nested objects without truncation when truncateZeroTimeInDates is false', () => {
+  const jsObject = {
+    project: {
+      name: "MyProject",
+      created: new Date('2024-01-15T00:00:00.000Z'),
+      metadata: {
+        last_updated: new Date('2024-02-20T14:30:00.000Z'),
+        start_date: new Date('2024-03-10T00:00:00.000Z'),
+      }
+    }
+  };
+
+  const result = stringify(jsObject, { truncateZeroTimeInDates: false });
+
+  const expected = dedent`
+    [project]
+    name = "MyProject"
+    created = 2024-01-15T00:00:00.000Z
+    metadata = { last_updated = 2024-02-20T14:30:00.000Z, start_date = 2024-03-10T00:00:00.000Z }
+    ` + '\n';
+
+  expect(result).toEqual(expected);
+});
+
+test('should handle mixed scenarios with dates in arrays, nested objects, and top-level with truncateZeroTimeInDates', () => {
+  const jsObject = {
+    top_level_date: new Date('2024-01-01T00:00:00.000Z'), // Zero time - should be truncated
+    top_level_datetime: new Date('2024-01-02T09:15:00.000Z'), // Non-zero time - should keep time
+    dates_array: [
+      new Date('2024-02-01T00:00:00.000Z'), // Zero time - should be truncated
+      new Date('2024-02-02T10:30:00.000Z'), // Non-zero time - should keep time
+    ],
+    config: {
+      created_at: new Date('2024-03-01T00:00:00.000Z'), // Zero time - should be truncated
+      updated_at: new Date('2024-03-02T16:45:00.000Z'), // Non-zero time - should keep time
+      milestones: [
+        new Date('2024-04-01T00:00:00.000Z'), // Zero time - should be truncated
+        new Date('2024-04-02T08:00:00.000Z'), // Non-zero time - should keep time
+      ]
+    }
+  };
+
+  const result = stringify(jsObject, { truncateZeroTimeInDates: true });
+
+  const expected = dedent`
+    top_level_date = 2024-01-01
+    top_level_datetime = 2024-01-02T09:15:00.000Z
+    dates_array = [ 2024-02-01, 2024-02-02T10:30:00.000Z ]
+
+    [config]
+    created_at = 2024-03-01
+    updated_at = 2024-03-02T16:45:00.000Z
+    milestones = [ 2024-04-01, 2024-04-02T08:00:00.000Z ]
+    ` + '\n';
+
+  expect(result).toEqual(expected);
+});
+
+test('should handle deeply nested objects with dates and truncateZeroTimeInDates', () => {
+  const jsObject = {
+    level1: {
+      date1: new Date('2024-01-15T00:00:00.000Z'), // Zero time - should be truncated
+      level2: {
+        date2: new Date('2024-02-20T11:30:00.000Z'), // Non-zero time - should keep time
+        level3: {
+          date3: new Date('2024-03-10T00:00:00.000Z'), // Zero time - should be truncated
+          value: "deep"
+        }
+      }
+    }
+  };
+
+  const result = stringify(jsObject, { truncateZeroTimeInDates: true });
+
+  const expected = dedent`
+    [level1]
+    date1 = 2024-01-15
+    level2 = { date2 = 2024-02-20T11:30:00.000Z, level3 = { date3 = 2024-03-10, value = "deep" } }
+    ` + '\n';
+
+  expect(result).toEqual(expected);
+});

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -19,6 +19,8 @@ import {
   Comment
 } from './ast';
 import { zero, cloneLocation, clonePosition } from './location';
+import { LocalDate } from './parse-toml';
+import { TomlFormat } from './toml-format';
 import { shiftNode } from './writer';
 
 /**
@@ -191,7 +193,18 @@ export function generateBoolean(value: boolean): Boolean {
   };
 }
 
-export function generateDateTime(value: Date): DateTime {
+export function generateDateTime(value: Date, format: TomlFormat): DateTime {
+  
+    // Convert Date objects with zero time components to LocalDate
+    // so they are serialized as date-only in TOML
+    if (format.truncateZeroTimeInDates &&
+        value.getUTCHours() === 0 &&
+        value.getUTCMinutes() === 0 &&
+        value.getUTCSeconds() === 0 &&
+        value.getUTCMilliseconds() === 0) {
+      value = new LocalDate(value.toISOString().split('T')[0]);
+    }
+  
   // Custom date classes have their own toISOString() implementations
   // that return the properly formatted strings for each TOML date/time type
   const raw = value.toISOString();

--- a/src/parse-js.ts
+++ b/src/parse-js.ts
@@ -14,6 +14,7 @@ import {
 import { TomlFormat, formatTopLevel, formatPrintWidth, formatEmptyLines, formatNestedTablesMultiline } from './toml-format';
 import { isObject, isString, isInteger, isFloat, isBoolean, isDate, pipe } from './utils';
 import { insert, applyWrites, applyBracketSpacing, applyTrailingComma } from './writer';
+import { LocalDate } from './date-format';
 
 
 export default function parseJS(value: any, format: TomlFormat = TomlFormat.default()): Document {
@@ -99,6 +100,16 @@ function walkValue(value: any, format: TomlFormat): Value {
   } else if (isBoolean(value)) {
     return generateBoolean(value);
   } else if (isDate(value)) {
+    // Convert Date objects with zero time components to LocalDate
+    // so they are serialized as date-only in TOML (only if truncateZeroTimeInDates is true)
+    if (format.truncateZeroTimeInDates &&
+        !(value instanceof LocalDate) &&
+        value.getUTCHours() === 0 &&
+        value.getUTCMinutes() === 0 &&
+        value.getUTCSeconds() === 0 &&
+        value.getUTCMilliseconds() === 0) {
+      value = new LocalDate(value.toISOString().split('T')[0]);
+    }
     return generateDateTime(value);
   } else if (Array.isArray(value)) {
     return walkInlineArray(value, format);

--- a/src/parse-js.ts
+++ b/src/parse-js.ts
@@ -14,7 +14,6 @@ import {
 import { TomlFormat, formatTopLevel, formatPrintWidth, formatEmptyLines, formatNestedTablesMultiline } from './toml-format';
 import { isObject, isString, isInteger, isFloat, isBoolean, isDate, pipe } from './utils';
 import { insert, applyWrites, applyBracketSpacing, applyTrailingComma } from './writer';
-import { LocalDate } from './date-format';
 
 
 export default function parseJS(value: any, format: TomlFormat = TomlFormat.default()): Document {
@@ -100,17 +99,7 @@ function walkValue(value: any, format: TomlFormat): Value {
   } else if (isBoolean(value)) {
     return generateBoolean(value);
   } else if (isDate(value)) {
-    // Convert Date objects with zero time components to LocalDate
-    // so they are serialized as date-only in TOML (only if truncateZeroTimeInDates is true)
-    if (format.truncateZeroTimeInDates &&
-        !(value instanceof LocalDate) &&
-        value.getUTCHours() === 0 &&
-        value.getUTCMinutes() === 0 &&
-        value.getUTCSeconds() === 0 &&
-        value.getUTCMilliseconds() === 0) {
-      value = new LocalDate(value.toISOString().split('T')[0]);
-    }
-    return generateDateTime(value);
+    return generateDateTime(value, format);
   } else if (Array.isArray(value)) {
     return walkInlineArray(value, format);
   } else {

--- a/src/toml-format.ts
+++ b/src/toml-format.ts
@@ -404,8 +404,13 @@ export class TomlFormat {
   inlineTableStart?: number;
 
   /**
-   * Whether to truncate time components in date fields when they are zero.
+   * Whether to truncate time components in UTC date fields when they are zero.
    * This setting affects only the stringification process.
+   * 
+   * @example  
+   * - true:  Date('2024-01-15T00:00:00.000Z') serializes as 2024-01-15
+   * - false: Date('2024-01-15T00:00:00.000Z') serializes as 2024-01-15T00:00:00.000Z
+   * 
    */
   truncateZeroTimeInDates?: boolean;
 
@@ -413,24 +418,22 @@ export class TomlFormat {
   //printWidth?: number;
   //tabWidth?: number;
   //useTabs?: boolean;
-  
-
 
   constructor(
-    newLine?: string, 
+    newLine?: string,
     trailingNewline?: number,
-     trailingComma?: boolean,
-     bracketSpacing?: boolean,
-     inlineTableStart?: number,
-     truncateZeroTimeInDates?: boolean
-    ) {
+    trailingComma?: boolean,
+    bracketSpacing?: boolean,
+    inlineTableStart?: number,
+    truncateZeroTimeInDates?: boolean
+  ) {
     // Use provided values or fall back to defaults
     this.newLine = newLine ?? DEFAULT_NEWLINE;
     this.trailingNewline = trailingNewline ?? DEFAULT_TRAILING_NEWLINE;
     this.trailingComma = trailingComma ?? DEFAULT_TRAILING_COMMA;
     this.bracketSpacing = bracketSpacing ?? DEFAULT_BRACKET_SPACING;
     this.inlineTableStart = inlineTableStart ?? DEFAULT_INLINE_TABLE_START;
-    this.truncateZeroTimeInDates = truncateZeroTimeInDates ?? DEFAULT_TRUNCATE_ZERO_TIME_IN_DATES; 
+    this.truncateZeroTimeInDates = truncateZeroTimeInDates ?? DEFAULT_TRUNCATE_ZERO_TIME_IN_DATES;
   }
 
   /**
@@ -442,6 +445,7 @@ export class TomlFormat {
    *   - trailingComma: false
    *   - bracketSpacing: true
    *   - inlineTableStart: 1
+   *   - truncateZeroTimeInDates: false
    */
   static default(): TomlFormat {
     return new TomlFormat(

--- a/src/toml-format.ts
+++ b/src/toml-format.ts
@@ -20,6 +20,7 @@ export const DEFAULT_TRAILING_NEWLINE = 1;
 export const DEFAULT_TRAILING_COMMA = false;
 export const DEFAULT_BRACKET_SPACING = true;
 export const DEFAULT_INLINE_TABLE_START = 1;
+export const DEFAULT_TRUNCATE_ZERO_TIME_IN_DATES = false;
 
 // Detects if trailing commas are used in the existing TOML by examining the AST
 // Returns true if trailing commas are used, false if not or comma-separated structures found (ie. default to false)
@@ -245,7 +246,7 @@ export function validateFormatObject(format: any): any {
     return {};
   }
 
-  const supportedProperties = new Set(['newLine', 'trailingNewline', 'trailingComma', 'bracketSpacing', 'inlineTableStart']);
+  const supportedProperties = new Set(['newLine', 'trailingNewline', 'trailingComma', 'bracketSpacing', 'inlineTableStart', 'truncateZeroTimeInDates']);
   const validatedFormat: any = {};
   const unsupportedProperties: string[] = [];
   const invalidTypeProperties: string[] = [];
@@ -276,6 +277,7 @@ export function validateFormatObject(format: any): any {
           
           case 'trailingComma':
           case 'bracketSpacing':
+          case 'truncateZeroTimeInDates':
             if (typeof value === 'boolean') {
               validatedFormat[key] = value;
             } else {
@@ -336,7 +338,8 @@ export function resolveTomlFormat(format: Partial<TomlFormat> | TomlFormat | und
         validatedFormat.trailingNewline ?? fallbackFormat.trailingNewline,
         validatedFormat.trailingComma ?? fallbackFormat.trailingComma,
         validatedFormat.bracketSpacing ?? fallbackFormat.bracketSpacing,
-        validatedFormat.inlineTableStart !== undefined ? validatedFormat.inlineTableStart : fallbackFormat.inlineTableStart
+        validatedFormat.inlineTableStart !== undefined ? validatedFormat.inlineTableStart : fallbackFormat.inlineTableStart,
+        validatedFormat.truncateZeroTimeInDates ?? fallbackFormat.truncateZeroTimeInDates,
       );
     }
   } else {
@@ -400,18 +403,34 @@ export class TomlFormat {
    */
   inlineTableStart?: number;
 
+  /**
+   * Whether to truncate time components in date fields when they are zero.
+   * This setting affects only the stringification process.
+   */
+  truncateZeroTimeInDates?: boolean;
+
   // These options were part of the original TimHall's version and are not yet implemented
   //printWidth?: number;
   //tabWidth?: number;
   //useTabs?: boolean;
   
-  constructor(newLine?: string, trailingNewline?: number, trailingComma?: boolean, bracketSpacing?: boolean, inlineTableStart?: number) {
+
+
+  constructor(
+    newLine?: string, 
+    trailingNewline?: number,
+     trailingComma?: boolean,
+     bracketSpacing?: boolean,
+     inlineTableStart?: number,
+     truncateZeroTimeInDates?: boolean
+    ) {
     // Use provided values or fall back to defaults
     this.newLine = newLine ?? DEFAULT_NEWLINE;
     this.trailingNewline = trailingNewline ?? DEFAULT_TRAILING_NEWLINE;
     this.trailingComma = trailingComma ?? DEFAULT_TRAILING_COMMA;
     this.bracketSpacing = bracketSpacing ?? DEFAULT_BRACKET_SPACING;
     this.inlineTableStart = inlineTableStart ?? DEFAULT_INLINE_TABLE_START;
+    this.truncateZeroTimeInDates = truncateZeroTimeInDates ?? DEFAULT_TRUNCATE_ZERO_TIME_IN_DATES; 
   }
 
   /**
@@ -430,7 +449,8 @@ export class TomlFormat {
       DEFAULT_TRAILING_NEWLINE,
       DEFAULT_TRAILING_COMMA,
       DEFAULT_BRACKET_SPACING,
-      DEFAULT_INLINE_TABLE_START
+      DEFAULT_INLINE_TABLE_START,
+      DEFAULT_TRUNCATE_ZERO_TIME_IN_DATES
     );
   }
 
@@ -478,6 +498,12 @@ export class TomlFormat {
     // inlineTableStart uses default value since auto-detection would require
     // complex analysis of nested table formatting preferences
     format.inlineTableStart = DEFAULT_INLINE_TABLE_START;
+
+    // truncateZeroTimeInDates uses default value as well
+    // We could always implement detection logic if needed
+    // That would imply checking if all dates have no time component in the TOML.
+    // However, it's not because all dates have no time component that a new key-value can't be introduced where the time component corresponds to midnight.
+    format.truncateZeroTimeInDates = DEFAULT_TRUNCATE_ZERO_TIME_IN_DATES;
     
     return format;
   }


### PR DESCRIPTION
Introduce a new format option, `truncateZeroTimeInDates`, to serialize Date objects with zero time components as date-only in TOML. This change includes tests to verify the behavior of date serialization based on this new option.