### PR TITLE
Fix multiline string handling when patching

### DIFF
--- a/src/__tests__/generate.test.ts
+++ b/src/__tests__/generate.test.ts
@@ -58,13 +58,14 @@ describe('generateString', () => {
   });
 
   describe('with multiline literal string format preservation', () => {
-    test('should escape three consecutive single quotes', () => {
+    test('should convert to basic string when value contains triple quotes', () => {
       const result = generateString("Three quotes: '''", "'''old'''");
       
       expect(result.type).toBe(NodeType.String);
       expect(result.value).toBe("Three quotes: '''");
-      expect(result.raw).toMatch(/^'''Three quotes: ''\\''.*'''$/);
-      expect(result.raw).toContain("''\\''");
+      // Should convert from literal (''') to basic (""")
+      // Note: ''' doesn't need escaping in basic strings, only """ needs escaping
+      expect(result.raw).toBe('"""Three quotes: \'\'\'"""');
     });
 
     test('should not escape backslashes in literal strings', () => {

--- a/src/__tests__/generate.test.ts
+++ b/src/__tests__/generate.test.ts
@@ -1,0 +1,94 @@
+import { generateString } from '../generate';
+import { NodeType } from '../ast';
+
+describe('generateString', () => {
+  describe('with multiline basic string format preservation', () => {
+    test('should escape three consecutive quotes correctly', () => {
+      const result = generateString('Three quotes: """', '"""old"""');
+      
+      expect(result.type).toBe(NodeType.String);
+      expect(result.value).toBe('Three quotes: """');
+      expect(result.raw).toBe('"""Three quotes: ""\\""""');
+    });
+
+    test('should escape four consecutive quotes correctly', () => {
+      const result = generateString('Four quotes: """"', '"""old"""');
+      
+      // Four quotes become: """ (matched) -> ""\" plus the remaining "
+      expect(result.raw).toBe('"""Four quotes: ""\\"""""');
+      expect(result.value).toBe('Four quotes: """"');
+    });
+
+    test('should escape five consecutive quotes correctly', () => {
+      const result = generateString('Five quotes: """""', '"""old"""');
+      
+      // Five quotes become: """ (matched) -> ""\" plus remaining ""
+      expect(result.raw).toBe('"""Five quotes: ""\\""""""');
+      expect(result.value).toBe('Five quotes: """""');
+    });
+
+    test('should escape backslashes before escaping quotes', () => {
+      const result = generateString('Backslash then quotes: \\"""', '"""old"""');
+      
+      expect(result.raw).toBe('"""Backslash then quotes: \\\\""\\""""');
+      expect(result.value).toBe('Backslash then quotes: \\"""');
+    });
+
+    test('should escape control characters', () => {
+      const result = generateString('Tab:\there\nNewline', '"""old"""');
+      
+      expect(result.raw).toContain('\\t');
+      expect(result.raw).not.toContain('\t'); // actual tab should be escaped
+      expect(result.value).toBe('Tab:\there\nNewline');
+    });
+
+    test('should handle strings without triple quotes', () => {
+      const result = generateString('Just a regular string', '"""old"""');
+      
+      expect(result.raw).toBe('"""Just a regular string"""');
+      expect(result.value).toBe('Just a regular string');
+    });
+
+    test('should handle one or two quotes (not escaped)', () => {
+      const result = generateString('One " or two "" quotes', '"""old"""');
+      
+      expect(result.raw).toBe('"""One " or two "" quotes"""');
+      expect(result.value).toBe('One " or two "" quotes');
+    });
+  });
+
+  describe('with multiline literal string format preservation', () => {
+    test('should escape three consecutive single quotes', () => {
+      const result = generateString("Three quotes: '''", "'''old'''");
+      
+      expect(result.type).toBe(NodeType.String);
+      expect(result.value).toBe("Three quotes: '''");
+      expect(result.raw).toMatch(/^'''Three quotes: ''\\''.*'''$/);
+      expect(result.raw).toContain("''\\''");
+    });
+
+    test('should not escape backslashes in literal strings', () => {
+      const result = generateString('Backslash: \\n', "'''old'''");
+      
+      expect(result.raw).toBe("'''Backslash: \\n'''");
+      expect(result.value).toBe('Backslash: \\n');
+      expect(result.raw).not.toContain('\\\\'); // backslashes should not be escaped
+    });
+  });
+
+  describe('without existing multiline format', () => {
+    test('should use JSON.stringify for regular strings', () => {
+      const result = generateString('Regular string with "quotes"');
+      
+      expect(result.raw).toBe('"Regular string with \\"quotes\\""');
+      expect(result.value).toBe('Regular string with "quotes"');
+    });
+
+    test('should escape triple quotes with JSON.stringify', () => {
+      const result = generateString('Triple """quotes"""');
+      
+      expect(result.raw).toBe('"Triple \\"\\"\\\"quotes\\"\\"\\""');
+      expect(result.value).toBe('Triple """quotes"""');
+    });
+  });
+});

--- a/src/__tests__/generate.test.ts
+++ b/src/__tests__/generate.test.ts
@@ -75,6 +75,30 @@ describe('generateString', () => {
       expect(result.value).toBe('Backslash: \\n');
       expect(result.raw).not.toContain('\\\\'); // backslashes should not be escaped
     });
+
+    test('should preserve leading newline when converting from literal to basic (with leading newline)', () => {
+      // Original literal string with leading newline: '''\nold'''
+      const result = generateString("new value with '''", "'''\nold'''");
+      
+      // Should convert to basic and preserve leading newline
+      expect(result.raw).toBe('"""\nnew value with \'\'\'"""');
+    });
+
+    test('should NOT add leading newline when converting from literal without leading newline', () => {
+      // Original literal string WITHOUT leading newline but WITH newline in content: '''old\nnewline'''
+      const result = generateString("value with '''", "'''old\nnewline'''");
+      
+      // Should convert to basic but NOT add leading newline (newline is in middle of content)
+      expect(result.raw).toBe('"""value with \'\'\'"""');
+    });
+
+    test('should preserve leading newline with CRLF when converting from literal to basic', () => {
+      // Original literal string with CRLF leading newline
+      const result = generateString("new with '''", "'''\r\nold'''");
+      
+      // Should convert to basic and preserve CRLF leading newline
+      expect(result.raw).toBe('"""\r\nnew with \'\'\'"""');
+    });
   });
 
   describe('without existing multiline format', () => {

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -309,6 +309,32 @@ test('should patch single-line multiline string to another single-line', () => {
   expect(patched).toEqual(expectedOutput);
 });
 
+test('should patch single-line multiline string to another single-line with newline at start and end', () => {
+  const existing = dedent`
+    [package]
+    name = "example"
+    description = """
+    A simple package
+    """
+    version = "1.0.0"
+    ` + '\n';
+
+  const obj = parse(existing);
+  obj.package.description = "A different description";
+  const patched = patch(existing, obj);
+  
+  let expectedOutput = dedent`
+    [package]
+    name = "example"
+    description = """
+    A different description
+    """
+    version = "1.0.0"
+    ` + '\n';
+
+  expect(patched).toEqual(expectedOutput);
+});
+
 
 test('should patch example with removal of an array element', () => {
   const existing = dedent`

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -327,8 +327,7 @@ test('should patch single-line multiline string to another single-line with newl
     [package]
     name = "example"
     description = """
-    A different description
-    """
+    A different description"""
     version = "1.0.0"
     ` + '\n';
 

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -575,6 +575,191 @@ test('should preserve multiline string with only newlines', () => {
   expect(patched).toEqual(expectedOutput);
 });
 
+// Parameterized tests for both basic (""") and literal (''') multiline strings
+describe('multiline strings - both basic and literal', () => {
+  test.each([
+    { delimiter: '"""', type: 'basic' },
+    { delimiter: "'''", type: 'literal' }
+  ])('should preserve $type multiline string format with simple content', ({ delimiter }) => {
+    const existing = dedent`
+      [package]
+      name = "example"
+      description = ${delimiter}
+      A simple package
+      ${delimiter}
+      version = "1.0.0"
+      ` + '\n';
+
+    const obj = parse(existing);
+    obj.package.description = "A different description";
+    const patched = patch(existing, obj);
+    
+    const expectedOutput = dedent`
+      [package]
+      name = "example"
+      description = ${delimiter}
+      A different description${delimiter}
+      version = "1.0.0"
+      ` + '\n';
+
+    expect(patched).toEqual(expectedOutput);
+  });
+
+  test.each([
+    { delimiter: '"""', type: 'basic' },
+    { delimiter: "'''", type: 'literal' }
+  ])('should preserve $type multiline string with multiple lines', ({ delimiter }) => {
+    const existing = dedent`
+      [package]
+      name = "example"
+      description = ${delimiter}
+      line one
+      line two
+      line three${delimiter}
+      version = "1.0.0"
+      ` + '\n';
+
+    const obj = parse(existing);
+    obj.package.description = "New line one\nNew line two\nNew line three";
+    const patched = patch(existing, obj);
+    
+    const expectedOutput = dedent`
+      [package]
+      name = "example"
+      description = ${delimiter}
+      New line one
+      New line two
+      New line three${delimiter}
+      version = "1.0.0"
+      ` + '\n';
+
+    expect(patched).toEqual(expectedOutput);
+  });
+
+  test.each([
+    { delimiter: '"""', type: 'basic' },
+    { delimiter: "'''", type: 'literal' }
+  ])('should preserve $type multiline string with empty content and leading newline', ({ delimiter }) => {
+    const existing = dedent`
+      [package]
+      name = "example"
+      description = ${delimiter}
+      ${delimiter}
+      version = "1.0.0"
+      ` + '\n';
+
+    const obj = parse(existing);
+    obj.package.description = "";
+    const patched = patch(existing, obj);
+    
+    const expectedOutput = dedent`
+      [package]
+      name = "example"
+      description = ${delimiter}
+      ${delimiter}
+      version = "1.0.0"
+      ` + '\n';
+
+    expect(patched).toEqual(expectedOutput);
+  });
+
+  test.each([
+    { delimiter: '"""', type: 'basic' },
+    { delimiter: "'''", type: 'literal' }
+  ])('should preserve $type multiline string with CRLF line endings', ({ delimiter }) => {
+    const existing = `[package]\r\nname = "example"\r\ndescription = ${delimiter}\r\nA simple package\r\n${delimiter}\r\nversion = "1.0.0"\r\n`;
+
+    const obj = parse(existing);
+    obj.package.description = "A different description";
+    const patched = patch(existing, obj);
+    
+    const expectedOutput = `[package]\r\nname = "example"\r\ndescription = ${delimiter}\r\nA different description${delimiter}\r\nversion = "1.0.0"\r\n`;
+
+    expect(patched).toEqual(expectedOutput);
+  });
+});
+
+// Specific tests for literal multiline strings (''') - testing literal behavior
+describe('literal multiline strings - specific behavior', () => {
+  test('should preserve literal multiline string without escaping backslashes', () => {
+    const existing = dedent`
+      [package]
+      name = "example"
+      path = '''
+      C:\\Users\\Example\\Path
+      '''
+      version = "1.0.0"
+      ` + '\n';
+
+    const obj = parse(existing);
+    // When setting a JavaScript string with single backslashes
+    obj.package.path = "D:\\Data\\Files";
+    const patched = patch(existing, obj);
+    
+    // In literal strings, backslashes are NOT doubled - they remain as single backslashes
+    const expectedOutput = dedent`
+      [package]
+      name = "example"
+      path = '''
+      D:\Data\Files'''
+      version = "1.0.0"
+      ` + '\n';
+
+    expect(patched).toEqual(expectedOutput);
+  });
+
+  test('should handle literal multiline string with actual newlines vs escape sequences', () => {
+    const existing = dedent`
+      [package]
+      name = "example"
+      text = '''
+      Old text
+      '''
+      version = "1.0.0"
+      ` + '\n';
+
+    const obj = parse(existing);
+    // Setting a JavaScript string that contains the characters \ and n
+    obj.package.text = "Line with \\n literal backslash-n";
+    const patched = patch(existing, obj);
+    
+    // Literal strings show backslash-n as actual characters (not newline)
+    // In the template we need to escape the backslash as \\n
+    const expectedOutput = `[package]
+name = "example"
+text = '''
+Line with \\n literal backslash-n'''
+version = "1.0.0"
+`;
+
+    expect(patched).toEqual(expectedOutput);
+  });
+
+  test('should handle literal multiline string with triple quotes in content', () => {
+    const existing = dedent`
+      [package]
+      name = "example"
+      text = '''Old text'''
+      version = "1.0.0"
+      ` + '\n';
+
+    const obj = parse(existing);
+    // Literal strings cannot contain ''' so it should convert to basic string
+    obj.package.text = "Text with ''' quotes";
+    const patched = patch(existing, obj);
+    
+    // Should convert from literal (''') to basic (""")
+    // Note: ''' doesn't need escaping in basic strings, only """ needs escaping
+    const expectedOutput = `[package]
+name = "example"
+text = """Text with ''' quotes"""
+version = "1.0.0"
+`;
+
+    expect(patched).toEqual(expectedOutput);
+  });
+});
+
 
 test('should patch example with removal of an array element', () => {
   const existing = dedent`

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -287,6 +287,28 @@ test('should patch example with triple quotes', () => {
   expect(patched).toEqual(expectedOutput);
 });
 
+test('should patch single-line multiline string to another single-line', () => {
+  const existing = dedent`
+    [package]
+    name = "example"
+    description = """A simple package"""
+    version = "1.0.0"
+    ` + '\n';
+
+  const obj = parse(existing);
+  obj.package.description = "A different description";
+  const patched = patch(existing, obj);
+  
+  let expectedOutput = dedent`
+    [package]
+    name = "example"
+    description = """A different description"""
+    version = "1.0.0"
+    ` + '\n';
+
+  expect(patched).toEqual(expectedOutput);
+});
+
 
 test('should patch example with removal of an array element', () => {
   const existing = dedent`

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -442,28 +442,6 @@ test('should preserve multiline string with empty content', () => {
   expect(patched).toEqual(expectedOutput);
 });
 
-test('should handle multiline string with escaped triple quotes', () => {
-  const existing = dedent`
-    [package]
-    name = "example"
-    description = """Contains \\"""triple quotes\\""" inside"""
-    version = "1.0.0"
-    ` + '\n';
-
-  const obj = parse(existing);
-  obj.package.description = 'Updated with """more quotes"""';
-  const patched = patch(existing, obj);
-  
-  let expectedOutput = dedent`
-    [package]
-    name = "example"
-    description = """Updated with \\"""more quotes\\""""""
-    version = "1.0.0"
-    ` + '\n';
-
-  expect(patched).toEqual(expectedOutput);
-});
-
 test('should preserve multiline string format when value contains backslashes', () => {
   const existing = dedent`
     [package]
@@ -475,15 +453,39 @@ test('should preserve multiline string format when value contains backslashes', 
     ` + '\n';
 
   const obj = parse(existing);
+  // Note: Multiline strings in TOML are literal strings (backslashes are not escaped)
+  // When we set a JavaScript string with single backslashes, they remain single in multiline TOML
   obj.package.description = "New path: D:\\Data\\Files\n";
+  const patched = patch(existing, obj);
+  
+  // In the expected output, we need to escape the backslashes in the JavaScript template string
+  const expectedOutput = `[package]
+name = "example"
+description = """
+New path: D:\\Data\\Files
+"""
+version = "1.0.0"
+`;
+
+  expect(patched).toEqual(expectedOutput);
+});
+
+test('should handle multiline string with triple quotes in content', () => {
+  const existing = dedent`
+    [package]
+    name = "example"
+    description = """Content without triple quotes"""
+    version = "1.0.0"
+    ` + '\n';
+
+  const obj = parse(existing);
+  obj.package.description = 'Updated content';
   const patched = patch(existing, obj);
   
   let expectedOutput = dedent`
     [package]
     name = "example"
-    description = """
-    New path: D:\\Data\\Files
-    """
+    description = """Updated content"""
     version = "1.0.0"
     ` + '\n';
 

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -373,14 +373,14 @@ test('should preserve multiline string with trailing newline in content', () => 
     ` + '\n';
 
   const obj = parse(existing);
-  obj.package.description = "New content with trailing\n";
+  obj.package.description = "New content with trailing newline\n";
   const patched = patch(existing, obj);
   
   let expectedOutput = dedent`
     [package]
     name = "example"
     description = """
-    New content with trailing
+    New content with trailing newline
     """
     version = "1.0.0"
     ` + '\n';
@@ -418,7 +418,7 @@ test('should preserve multiline string with multiple trailing newlines', () => {
   expect(patched).toEqual(expectedOutput);
 });
 
-test('should preserve multiline string with empty content', () => {
+test('should preserve multiline string with empty content and newline at the start', () => {
   const existing = dedent`
     [package]
     name = "example"
@@ -442,27 +442,49 @@ test('should preserve multiline string with empty content', () => {
   expect(patched).toEqual(expectedOutput);
 });
 
+test('should preserve multiline string with empty content without newline at the start', () => {
+  const existing = dedent`
+    [package]
+    name = "example"
+    description = """"""
+    version = "1.0.0"
+    ` + '\n';
+
+  const obj = parse(existing);
+  obj.package.description = "";
+  const patched = patch(existing, obj);
+  
+  let expectedOutput = dedent`
+    [package]
+    name = "example"
+    description = """"""
+    version = "1.0.0"
+    ` + '\n';
+
+  expect(patched).toEqual(expectedOutput);
+});
+
 test('should preserve multiline string format when value contains backslashes', () => {
   const existing = dedent`
     [package]
     name = "example"
     description = """
-    Path: C:\\Users\\Example
+    Path: C:\\\\Users\\\\Example
     """
     version = "1.0.0"
     ` + '\n';
 
   const obj = parse(existing);
-  // Note: Multiline strings in TOML are literal strings (backslashes are not escaped)
-  // When we set a JavaScript string with single backslashes, they remain single in multiline TOML
+  // Note: Multiline BASIC strings (""") DO escape backslashes (unlike literal strings with ''')
+  // When we set a JavaScript string with a backslash, it needs to be escaped as \\ in the TOML output
   obj.package.description = "New path: D:\\Data\\Files\n";
   const patched = patch(existing, obj);
   
-  // In the expected output, we need to escape the backslashes in the JavaScript template string
+  // In the expected output, backslashes are escaped in the multiline basic string
   const expectedOutput = `[package]
 name = "example"
 description = """
-New path: D:\\Data\\Files
+New path: D:\\\\Data\\\\Files
 """
 version = "1.0.0"
 `;

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -758,6 +758,57 @@ version = "1.0.0"
 
     expect(patched).toEqual(expectedOutput);
   });
+
+  test('should NOT add leading newline when converting literal string with newline in middle', () => {
+    const existing = dedent`
+      [package]
+      name = "example"
+      text = '''line one
+      line two'''
+      version = "1.0.0"
+      ` + '\n';
+
+    const obj = parse(existing);
+    // Change value to require conversion to basic string
+    obj.package.text = "has ''' quotes";
+    const patched = patch(existing, obj);
+    
+    // Should convert to basic string WITHOUT leading newline
+    // (the original literal string had newline in content, not at the start)
+    const expectedOutput = `[package]
+name = "example"
+text = """has ''' quotes"""
+version = "1.0.0"
+`;
+
+    expect(patched).toEqual(expectedOutput);
+  });
+
+  test('should preserve leading newline when converting literal string with leading newline', () => {
+    const existing = dedent`
+      [package]
+      name = "example"
+      text = '''
+      Old text
+      '''
+      version = "1.0.0"
+      ` + '\n';
+
+    const obj = parse(existing);
+    // Change value to require conversion to basic string
+    obj.package.text = "New with ''' quotes";
+    const patched = patch(existing, obj);
+    
+    // Should convert to basic string WITH leading newline
+    const expectedOutput = `[package]
+name = "example"
+text = """
+New with ''' quotes"""
+version = "1.0.0"
+`;
+
+    expect(patched).toEqual(expectedOutput);
+  });
 });
 
 

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -334,6 +334,223 @@ test('should patch single-line multiline string to another single-line with newl
   expect(patched).toEqual(expectedOutput);
 });
 
+test('should preserve multiline string with actual multiple lines', () => {
+  const existing = dedent`
+    [package]
+    name = "example"
+    description = """
+    First line
+    Second line
+    Third line"""
+    version = "1.0.0"
+    ` + '\n';
+
+  const obj = parse(existing);
+  obj.package.description = "Updated line one\nUpdated line two\nUpdated line three";
+  const patched = patch(existing, obj);
+  
+  let expectedOutput = dedent`
+    [package]
+    name = "example"
+    description = """
+    Updated line one
+    Updated line two
+    Updated line three"""
+    version = "1.0.0"
+    ` + '\n';
+
+  expect(patched).toEqual(expectedOutput);
+});
+
+test('should preserve multiline string with trailing newline in content', () => {
+  const existing = dedent`
+    [package]
+    name = "example"
+    description = """
+    Content with trailing newline
+    """
+    version = "1.0.0"
+    ` + '\n';
+
+  const obj = parse(existing);
+  obj.package.description = "New content with trailing\n";
+  const patched = patch(existing, obj);
+  
+  let expectedOutput = dedent`
+    [package]
+    name = "example"
+    description = """
+    New content with trailing
+    """
+    version = "1.0.0"
+    ` + '\n';
+
+  expect(patched).toEqual(expectedOutput);
+});
+
+test('should preserve multiline string with multiple trailing newlines', () => {
+  const existing = dedent`
+    [package]
+    name = "example"
+    description = """
+    Content
+
+
+    """
+    version = "1.0.0"
+    ` + '\n';
+
+  const obj = parse(existing);
+  obj.package.description = "New content\n\n\n";
+  const patched = patch(existing, obj);
+  
+  let expectedOutput = dedent`
+    [package]
+    name = "example"
+    description = """
+    New content
+
+
+    """
+    version = "1.0.0"
+    ` + '\n';
+
+  expect(patched).toEqual(expectedOutput);
+});
+
+test('should preserve multiline string with empty content', () => {
+  const existing = dedent`
+    [package]
+    name = "example"
+    description = """
+    """
+    version = "1.0.0"
+    ` + '\n';
+
+  const obj = parse(existing);
+  obj.package.description = "";
+  const patched = patch(existing, obj);
+  
+  let expectedOutput = dedent`
+    [package]
+    name = "example"
+    description = """
+    """
+    version = "1.0.0"
+    ` + '\n';
+
+  expect(patched).toEqual(expectedOutput);
+});
+
+test('should handle multiline string with escaped triple quotes', () => {
+  const existing = dedent`
+    [package]
+    name = "example"
+    description = """Contains \\"""triple quotes\\""" inside"""
+    version = "1.0.0"
+    ` + '\n';
+
+  const obj = parse(existing);
+  obj.package.description = 'Updated with """more quotes"""';
+  const patched = patch(existing, obj);
+  
+  let expectedOutput = dedent`
+    [package]
+    name = "example"
+    description = """Updated with \\"""more quotes\\""""""
+    version = "1.0.0"
+    ` + '\n';
+
+  expect(patched).toEqual(expectedOutput);
+});
+
+test('should preserve multiline string format when value contains backslashes', () => {
+  const existing = dedent`
+    [package]
+    name = "example"
+    description = """
+    Path: C:\\Users\\Example
+    """
+    version = "1.0.0"
+    ` + '\n';
+
+  const obj = parse(existing);
+  obj.package.description = "New path: D:\\Data\\Files\n";
+  const patched = patch(existing, obj);
+  
+  let expectedOutput = dedent`
+    [package]
+    name = "example"
+    description = """
+    New path: D:\\Data\\Files
+    """
+    version = "1.0.0"
+    ` + '\n';
+
+  expect(patched).toEqual(expectedOutput);
+});
+
+test('should preserve multiline string with CRLF line endings', () => {
+  const existing = '[package]\r\nname = "example"\r\ndescription = """\r\nA simple package\r\n"""\r\nversion = "1.0.0"\r\n';
+
+  const obj = parse(existing);
+  obj.package.description = "A different description";
+  const patched = patch(existing, obj);
+  
+  const expectedOutput = '[package]\r\nname = "example"\r\ndescription = """\r\nA different description"""\r\nversion = "1.0.0"\r\n';
+
+  expect(patched).toEqual(expectedOutput);
+});
+
+test('should handle conversion from regular string to multiline string format preserved', () => {
+  const existing = dedent`
+    [package]
+    name = "example"
+    description = "Regular string"
+    version = "1.0.0"
+    ` + '\n';
+
+  const obj = parse(existing);
+  obj.package.description = "Updated string";
+  const patched = patch(existing, obj);
+  
+  // Should remain as regular string since original was regular
+  let expectedOutput = dedent`
+    [package]
+    name = "example"
+    description = "Updated string"
+    version = "1.0.0"
+    ` + '\n';
+
+  expect(patched).toEqual(expectedOutput);
+});
+
+test('should preserve multiline string with only newlines', () => {
+  const existing = dedent`
+    [package]
+    name = "example"
+    description = """
+
+    """
+    version = "1.0.0"
+    ` + '\n';
+
+  const obj = parse(existing);
+  obj.package.description = "\n";
+  const patched = patch(existing, obj);
+  
+  let expectedOutput = dedent`
+    [package]
+    name = "example"
+    description = """
+
+    """
+    version = "1.0.0"
+    ` + '\n';
+
+  expect(patched).toEqual(expectedOutput);
+});
+
 
 test('should patch example with removal of an array element', () => {
   const existing = dedent`

--- a/src/__tests__/stringify.test.ts
+++ b/src/__tests__/stringify.test.ts
@@ -635,3 +635,52 @@ test('should handle deeply nested objects with dates and truncateZeroTimeInDates
 
   expect(result).toEqual(expected);
 });
+
+test('should handle strings with triple quotes when stringifying JS objects', () => {
+  const obj = {
+    text: 'Three quotes: """'
+  };
+  
+  const result = stringify(obj);
+  
+  // Should escape triple quotes properly
+  expect(result).toBe('text = "Three quotes: \\"\\"\\\""\n');
+  
+  // The result should be parseable
+  const { parse } = require('../');
+  const parsed = parse(result);
+  expect(parsed.text).toBe('Three quotes: """');
+});
+
+test('should handle strings with four consecutive quotes when stringifying JS objects', () => {
+  const obj = {
+    text: 'Four quotes: """"'
+  };
+  
+  const result = stringify(obj);
+  
+  // Should escape all four quotes
+  expect(result).toBe('text = "Four quotes: \\"\\"\\"\\\""\n');
+  
+  // The result should be parseable
+  const { parse } = require('../');
+  const parsed = parse(result);
+  expect(parsed.text).toBe('Four quotes: """"');
+});
+
+test('should handle strings with backslashes and quotes when stringifying JS objects', () => {
+  const obj = {
+    text: 'Backslash then quotes: \\"""'
+  };
+  
+  const result = stringify(obj);
+  
+  // Should escape backslash and then quotes
+  expect(result).toContain('\\\\'); // escaped backslash
+  expect(result).toContain('\\"'); // escaped quotes
+  
+  // The result should be parseable
+  const { parse } = require('../');
+  const parsed = parse(result);
+  expect(parsed.text).toBe('Backslash then quotes: \\"""');
+});

--- a/src/__tests__/writer.test.ts
+++ b/src/__tests__/writer.test.ts
@@ -1,4 +1,4 @@
-import { insert, applyWrites, formatMultilineStringReplacement } from '../writer';
+import { insert, applyWrites, fixStringLocation } from '../writer';
 import toTOML from '../to-toml';
 import {
   generateInlineArray,
@@ -58,7 +58,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"""old"""', 'old');
       const escapedReplacement = generateString('Three quotes: """', existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      const result = fixStringLocation(existing, escapedReplacement);
       
       // Three quotes should be escaped as: two literal quotes + escaped quote
       expect(result.raw).toBe('"""Three quotes: ""\\""""');
@@ -68,7 +68,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"""old"""', 'old');
       const escapedReplacement = generateString('Four quotes: """"', existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      const result = fixStringLocation(existing, escapedReplacement);
       
       // First three quotes escaped as ""\" and fourth remains literal
       expect(result.raw).toBe('"""Four quotes: ""\\"""""');
@@ -78,7 +78,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"""old"""', 'old');
       const escapedReplacement = generateString('Five quotes: """""', existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      const result = fixStringLocation(existing, escapedReplacement);
       
       // Pattern: ""\" + remaining quotes
       expect(result.raw).toBe('"""Five quotes: ""\\""""""');
@@ -88,7 +88,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"""old"""', 'old');
       const escapedReplacement = generateString('Six quotes: """"""', existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      const result = fixStringLocation(existing, escapedReplacement);
       
       // Two sets of three quotes: ""\" + """ (second set becomes ""\")
       // Input: """""" -> First three (""") becomes ""\", next three (""") becomes ""\"
@@ -99,7 +99,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"""old"""', 'old');
       const escapedReplacement = generateString('First: """ and second: """', existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      const result = fixStringLocation(existing, escapedReplacement);
       
       expect(result.raw).toBe('"""First: ""\\" and second: ""\\""""');
     });
@@ -108,7 +108,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"""old"""', 'old');
       const escapedReplacement = generateString('Path: C:\\Data and quotes: """', existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      const result = fixStringLocation(existing, escapedReplacement);
       
       // Backslashes escaped first, then quotes
       expect(result.raw).toBe('"""Path: C:\\\\Data and quotes: ""\\""""');
@@ -118,7 +118,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"""old"""', 'old');
       const escapedReplacement = generateString('One " or two "" quotes', existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      const result = fixStringLocation(existing, escapedReplacement);
       
       // Single and double quotes are allowed unescaped
       expect(result.raw).toBe('"""One " or two "" quotes"""');
@@ -128,7 +128,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"""old"""', 'old');
       const escapedReplacement = generateString('Tab:\there Newline:\nallowed', existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      const result = fixStringLocation(existing, escapedReplacement);
       
       // Tab escaped, newlines allowed in multiline strings
       expect(result.raw).toBe('"""Tab:\\there Newline:\nallowed"""');
@@ -140,7 +140,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode("'''old'''", 'old');
       const escapedReplacement = generateString("Three quotes: '''", existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      const result = fixStringLocation(existing, escapedReplacement);
       
       // Should convert from literal (''') to basic (""")
       // Note: ''' doesn't need escaping in basic strings
@@ -151,7 +151,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode("'''old'''", 'old');
       const escapedReplacement = generateString("Path: C:\\Data\\Files", existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      const result = fixStringLocation(existing, escapedReplacement);
       
       // Backslashes are literal in ''' strings
       expect(result.raw).toBe("'''Path: C:\\Data\\Files'''");
@@ -163,7 +163,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"regular"', 'regular');
       const replacement = createStringNode('"new"', 'new value');
       
-      const result = formatMultilineStringReplacement(existing, replacement);
+      const result = fixStringLocation(existing, replacement);
       
       // Should return the original replacement unchanged
       expect(result).toBe(replacement);
@@ -175,7 +175,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"""\nold"""', 'old');
       const escapedReplacement = generateString('new value', existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      const result = fixStringLocation(existing, escapedReplacement);
       
       expect(result.raw).toBe('"""\nnew value"""');
     });
@@ -184,7 +184,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"""\r\nold"""', 'old');
       const escapedReplacement = generateString('new value', existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      const result = fixStringLocation(existing, escapedReplacement);
       
       expect(result.raw).toBe('"""\r\nnew value"""');
     });
@@ -197,7 +197,7 @@ describe('formatMultilineStringReplacement', () => {
       existing.loc = { start: { line: 1, column: 10 }, end: { line: 1, column: 19 } };
       
       const escapedReplacement = generateString('new longer value', existing.raw);
-      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      const result = fixStringLocation(existing, escapedReplacement);
       
       // Should update end column to reflect new length
       expect(result.loc.start).toEqual({ line: 1, column: 10 });
@@ -211,7 +211,7 @@ describe('formatMultilineStringReplacement', () => {
       existing.loc = { start: { line: 1, column: 10 }, end: { line: 3, column: 3 } };
       
       const escapedReplacement = generateString('new\nmultiline\nvalue', existing.raw);
-      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      const result = fixStringLocation(existing, escapedReplacement);
       
       // Should update end line based on number of newlines
       expect(result.loc.start).toEqual({ line: 1, column: 10 });
@@ -224,7 +224,7 @@ describe('formatMultilineStringReplacement', () => {
       existing.loc = { start: { line: 5, column: 0 }, end: { line: 5, column: 7 } };
       
       const escapedReplacement = generateString('much longer replacement value', existing.raw);
-      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      const result = fixStringLocation(existing, escapedReplacement);
       
       expect(result.loc.start).toEqual({ line: 5, column: 0 });
       expect(result.loc.end).toEqual({ line: 5, column: result.raw.length });
@@ -236,7 +236,7 @@ describe('formatMultilineStringReplacement', () => {
       existing.loc = { start: { line: 2, column: 5 }, end: { line: 2, column: 35 } };
       
       const escapedReplacement = generateString('x', existing.raw);
-      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      const result = fixStringLocation(existing, escapedReplacement);
       
       expect(result.loc.start).toEqual({ line: 2, column: 5 });
       expect(result.loc.end).toEqual({ line: 2, column: 5 + result.raw.length });
@@ -248,7 +248,7 @@ describe('formatMultilineStringReplacement', () => {
       existing.loc = { start: { line: 1, column: 0 }, end: { line: 3, column: 3 } };
       
       const escapedReplacement = generateString('new\r\nvalue', existing.raw);
-      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      const result = fixStringLocation(existing, escapedReplacement);
       
       // Should count CRLF as line breaks
       expect(result.loc.start).toEqual({ line: 1, column: 0 });

--- a/src/__tests__/writer.test.ts
+++ b/src/__tests__/writer.test.ts
@@ -56,9 +56,9 @@ describe('formatMultilineStringReplacement', () => {
   describe('basic multiline strings (""")', () => {
     test('should escape three consecutive quotes correctly', () => {
       const existing = createStringNode('"""old"""', 'old');
-      const replacement = createStringNode('"new"', 'Three quotes: """');
+      const escapedReplacement = generateString('Three quotes: """', existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, replacement);
+      const result = formatMultilineStringReplacement(existing, escapedReplacement);
       
       // Three quotes should be escaped as: two literal quotes + escaped quote
       expect(result.raw).toBe('"""Three quotes: ""\\""""');
@@ -66,9 +66,9 @@ describe('formatMultilineStringReplacement', () => {
 
     test('should escape four consecutive quotes correctly', () => {
       const existing = createStringNode('"""old"""', 'old');
-      const replacement = createStringNode('"new"', 'Four quotes: """"');
+      const escapedReplacement = generateString('Four quotes: """"', existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, replacement);
+      const result = formatMultilineStringReplacement(existing, escapedReplacement);
       
       // First three quotes escaped as ""\" and fourth remains literal
       expect(result.raw).toBe('"""Four quotes: ""\\"""""');
@@ -76,9 +76,9 @@ describe('formatMultilineStringReplacement', () => {
 
     test('should escape five consecutive quotes correctly', () => {
       const existing = createStringNode('"""old"""', 'old');
-      const replacement = createStringNode('"new"', 'Five quotes: """""');
+      const escapedReplacement = generateString('Five quotes: """""', existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, replacement);
+      const result = formatMultilineStringReplacement(existing, escapedReplacement);
       
       // Pattern: ""\" + remaining quotes
       expect(result.raw).toBe('"""Five quotes: ""\\""""""');
@@ -86,9 +86,9 @@ describe('formatMultilineStringReplacement', () => {
 
     test('should escape six consecutive quotes correctly', () => {
       const existing = createStringNode('"""old"""', 'old');
-      const replacement = createStringNode('"new"', 'Six quotes: """"""');
+      const escapedReplacement = generateString('Six quotes: """"""', existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, replacement);
+      const result = formatMultilineStringReplacement(existing, escapedReplacement);
       
       // Two sets of three quotes: ""\" + """ (second set becomes ""\")
       // Input: """""" -> First three (""") becomes ""\", next three (""") becomes ""\"
@@ -97,18 +97,18 @@ describe('formatMultilineStringReplacement', () => {
 
     test('should handle multiple triple quote sequences', () => {
       const existing = createStringNode('"""old"""', 'old');
-      const replacement = createStringNode('"new"', 'First: """ and second: """');
+      const escapedReplacement = generateString('First: """ and second: """', existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, replacement);
+      const result = formatMultilineStringReplacement(existing, escapedReplacement);
       
       expect(result.raw).toBe('"""First: ""\\" and second: ""\\""""');
     });
 
     test('should escape backslashes before escaping quotes', () => {
       const existing = createStringNode('"""old"""', 'old');
-      const replacement = createStringNode('"new"', 'Path: C:\\Data and quotes: """');
+      const escapedReplacement = generateString('Path: C:\\Data and quotes: """', existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, replacement);
+      const result = formatMultilineStringReplacement(existing, escapedReplacement);
       
       // Backslashes escaped first, then quotes
       expect(result.raw).toBe('"""Path: C:\\\\Data and quotes: ""\\""""');
@@ -116,9 +116,9 @@ describe('formatMultilineStringReplacement', () => {
 
     test('should handle one or two quotes (not escaped)', () => {
       const existing = createStringNode('"""old"""', 'old');
-      const replacement = createStringNode('"new"', 'One " or two "" quotes');
+      const escapedReplacement = generateString('One " or two "" quotes', existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, replacement);
+      const result = formatMultilineStringReplacement(existing, escapedReplacement);
       
       // Single and double quotes are allowed unescaped
       expect(result.raw).toBe('"""One " or two "" quotes"""');
@@ -126,21 +126,21 @@ describe('formatMultilineStringReplacement', () => {
 
     test('should escape control characters', () => {
       const existing = createStringNode('"""old"""', 'old');
-      const replacement = createStringNode('"new"', 'Tab:\there Newline:\nallowed');
+      const escapedReplacement = generateString('Tab:\there Newline:\nallowed', existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, replacement);
+      const result = formatMultilineStringReplacement(existing, escapedReplacement);
       
       // Tab escaped, newlines allowed in multiline strings
       expect(result.raw).toBe('"""Tab:\\there Newline:\nallowed"""');
     });
   });
 
-  describe('literal multiline strings (\'\'\')', () => {
+  describe("literal multiline strings (''')", () => {
     test('should escape three consecutive single quotes', () => {
       const existing = createStringNode("'''old'''", 'old');
-      const replacement = createStringNode("'new'", "Three quotes: '''");
+      const escapedReplacement = generateString("Three quotes: '''", existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, replacement);
+      const result = formatMultilineStringReplacement(existing, escapedReplacement);
       
       // Verify the escaping pattern: opening ''' + content with escaped quotes + closing '''
       expect(result.raw).toMatch(/^'''Three quotes: ''\\''.*'''$/);
@@ -149,9 +149,9 @@ describe('formatMultilineStringReplacement', () => {
 
     test('should not escape backslashes in literal strings', () => {
       const existing = createStringNode("'''old'''", 'old');
-      const replacement = createStringNode("'new'", "Path: C:\\Data\\Files");
+      const escapedReplacement = generateString("Path: C:\\Data\\Files", existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, replacement);
+      const result = formatMultilineStringReplacement(existing, escapedReplacement);
       
       // Backslashes are literal in ''' strings
       expect(result.raw).toBe("'''Path: C:\\Data\\Files'''");
@@ -173,18 +173,18 @@ describe('formatMultilineStringReplacement', () => {
   describe('newline handling', () => {
     test('should preserve leading newline format', () => {
       const existing = createStringNode('"""\nold"""', 'old');
-      const replacement = createStringNode('"new"', 'new value');
+      const escapedReplacement = generateString('new value', existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, replacement);
+      const result = formatMultilineStringReplacement(existing, escapedReplacement);
       
       expect(result.raw).toBe('"""\nnew value"""');
     });
 
     test('should detect and use CRLF line endings', () => {
       const existing = createStringNode('"""\r\nold"""', 'old');
-      const replacement = createStringNode('"new"', 'new value');
+      const escapedReplacement = generateString('new value', existing.raw);
       
-      const result = formatMultilineStringReplacement(existing, replacement);
+      const result = formatMultilineStringReplacement(existing, escapedReplacement);
       
       expect(result.raw).toBe('"""\r\nnew value"""');
     });

--- a/src/__tests__/writer.test.ts
+++ b/src/__tests__/writer.test.ts
@@ -1,4 +1,4 @@
-import { insert, applyWrites } from '../writer';
+import { insert, applyWrites, formatMultilineStringReplacement } from '../writer';
 import toTOML from '../to-toml';
 import {
   generateInlineArray,
@@ -8,6 +8,7 @@ import {
   generateDocument
 } from '../generate';
 import { TomlFormat } from '../toml-format';
+import { String as StringNode, NodeType } from '../ast';
 
 test('it should insert elements into empty inline array', () => {
   const inline_array = generateInlineArray();
@@ -38,4 +39,154 @@ test('it should insert first item on first line in document', () => {
   insert(document, document, item);
 
   expect(toTOML(document.items, format)).toEqual(`a = "b"\n`);
+});
+
+describe('formatMultilineStringReplacement', () => {
+  // Helper function to create a mock String node
+  const createStringNode = (raw: string, value: string): StringNode => ({
+    type: NodeType.String,
+    raw,
+    value,
+    loc: {
+      start: { line: 1, column: 0 },
+      end: { line: 1, column: raw.length }
+    }
+  });
+
+  describe('basic multiline strings (""")', () => {
+    test('should escape three consecutive quotes correctly', () => {
+      const existing = createStringNode('"""old"""', 'old');
+      const replacement = createStringNode('"new"', 'Three quotes: """');
+      
+      const result = formatMultilineStringReplacement(existing, replacement);
+      
+      // Three quotes should be escaped as: two literal quotes + escaped quote
+      expect(result.raw).toBe('"""Three quotes: ""\\""""');
+    });
+
+    test('should escape four consecutive quotes correctly', () => {
+      const existing = createStringNode('"""old"""', 'old');
+      const replacement = createStringNode('"new"', 'Four quotes: """"');
+      
+      const result = formatMultilineStringReplacement(existing, replacement);
+      
+      // First three quotes escaped as ""\" and fourth remains literal
+      expect(result.raw).toBe('"""Four quotes: ""\\"""""');
+    });
+
+    test('should escape five consecutive quotes correctly', () => {
+      const existing = createStringNode('"""old"""', 'old');
+      const replacement = createStringNode('"new"', 'Five quotes: """""');
+      
+      const result = formatMultilineStringReplacement(existing, replacement);
+      
+      // Pattern: ""\" + remaining quotes
+      expect(result.raw).toBe('"""Five quotes: ""\\""""""');
+    });
+
+    test('should escape six consecutive quotes correctly', () => {
+      const existing = createStringNode('"""old"""', 'old');
+      const replacement = createStringNode('"new"', 'Six quotes: """"""');
+      
+      const result = formatMultilineStringReplacement(existing, replacement);
+      
+      // Two sets of three quotes: ""\" + """ (second set becomes ""\")
+      // Input: """""" -> First three (""") becomes ""\", next three (""") becomes ""\"
+      expect(result.raw).toBe('"""Six quotes: ""\\"""\\""""');
+    });
+
+    test('should handle multiple triple quote sequences', () => {
+      const existing = createStringNode('"""old"""', 'old');
+      const replacement = createStringNode('"new"', 'First: """ and second: """');
+      
+      const result = formatMultilineStringReplacement(existing, replacement);
+      
+      expect(result.raw).toBe('"""First: ""\\" and second: ""\\""""');
+    });
+
+    test('should escape backslashes before escaping quotes', () => {
+      const existing = createStringNode('"""old"""', 'old');
+      const replacement = createStringNode('"new"', 'Path: C:\\Data and quotes: """');
+      
+      const result = formatMultilineStringReplacement(existing, replacement);
+      
+      // Backslashes escaped first, then quotes
+      expect(result.raw).toBe('"""Path: C:\\\\Data and quotes: ""\\""""');
+    });
+
+    test('should handle one or two quotes (not escaped)', () => {
+      const existing = createStringNode('"""old"""', 'old');
+      const replacement = createStringNode('"new"', 'One " or two "" quotes');
+      
+      const result = formatMultilineStringReplacement(existing, replacement);
+      
+      // Single and double quotes are allowed unescaped
+      expect(result.raw).toBe('"""One " or two "" quotes"""');
+    });
+
+    test('should escape control characters', () => {
+      const existing = createStringNode('"""old"""', 'old');
+      const replacement = createStringNode('"new"', 'Tab:\there Newline:\nallowed');
+      
+      const result = formatMultilineStringReplacement(existing, replacement);
+      
+      // Tab escaped, newlines allowed in multiline strings
+      expect(result.raw).toBe('"""Tab:\\there Newline:\nallowed"""');
+    });
+  });
+
+  describe('literal multiline strings (\'\'\')', () => {
+    test('should escape three consecutive single quotes', () => {
+      const existing = createStringNode("'''old'''", 'old');
+      const replacement = createStringNode("'new'", "Three quotes: '''");
+      
+      const result = formatMultilineStringReplacement(existing, replacement);
+      
+      // Verify the escaping pattern: opening ''' + content with escaped quotes + closing '''
+      expect(result.raw).toMatch(/^'''Three quotes: ''\\''.*'''$/);
+      expect(result.raw.includes("''\\''")).toBe(true);
+    });
+
+    test('should not escape backslashes in literal strings', () => {
+      const existing = createStringNode("'''old'''", 'old');
+      const replacement = createStringNode("'new'", "Path: C:\\Data\\Files");
+      
+      const result = formatMultilineStringReplacement(existing, replacement);
+      
+      // Backslashes are literal in ''' strings
+      expect(result.raw).toBe("'''Path: C:\\Data\\Files'''");
+    });
+  });
+
+  describe('non-multiline strings', () => {
+    test('should return replacement unchanged for regular strings', () => {
+      const existing = createStringNode('"regular"', 'regular');
+      const replacement = createStringNode('"new"', 'new value');
+      
+      const result = formatMultilineStringReplacement(existing, replacement);
+      
+      // Should return the original replacement unchanged
+      expect(result).toBe(replacement);
+    });
+  });
+
+  describe('newline handling', () => {
+    test('should preserve leading newline format', () => {
+      const existing = createStringNode('"""\nold"""', 'old');
+      const replacement = createStringNode('"new"', 'new value');
+      
+      const result = formatMultilineStringReplacement(existing, replacement);
+      
+      expect(result.raw).toBe('"""\nnew value"""');
+    });
+
+    test('should detect and use CRLF line endings', () => {
+      const existing = createStringNode('"""\r\nold"""', 'old');
+      const replacement = createStringNode('"new"', 'new value');
+      
+      const result = formatMultilineStringReplacement(existing, replacement);
+      
+      expect(result.raw).toBe('"""\r\nnew value"""');
+    });
+  });
 });

--- a/src/__tests__/writer.test.ts
+++ b/src/__tests__/writer.test.ts
@@ -136,15 +136,15 @@ describe('formatMultilineStringReplacement', () => {
   });
 
   describe("literal multiline strings (''')", () => {
-    test('should escape three consecutive single quotes', () => {
+    test('should convert to basic string when value contains triple quotes', () => {
       const existing = createStringNode("'''old'''", 'old');
       const escapedReplacement = generateString("Three quotes: '''", existing.raw);
       
       const result = formatMultilineStringReplacement(existing, escapedReplacement);
       
-      // Verify the escaping pattern: opening ''' + content with escaped quotes + closing '''
-      expect(result.raw).toMatch(/^'''Three quotes: ''\\''.*'''$/);
-      expect(result.raw.includes("''\\''")).toBe(true);
+      // Should convert from literal (''') to basic (""")
+      // Note: ''' doesn't need escaping in basic strings
+      expect(result.raw).toBe('"""Three quotes: \'\'\'"""');
     });
 
     test('should not escape backslashes in literal strings', () => {

--- a/src/__tests__/writer.test.ts
+++ b/src/__tests__/writer.test.ts
@@ -189,4 +189,71 @@ describe('formatMultilineStringReplacement', () => {
       expect(result.raw).toBe('"""\r\nnew value"""');
     });
   });
+
+  describe('location tracking', () => {
+    test('should update location for single-line multiline string (no leading newline)', () => {
+      // Single-line multiline string like """content"""
+      const existing = createStringNode('"""old"""', 'old');
+      existing.loc = { start: { line: 1, column: 10 }, end: { line: 1, column: 19 } };
+      
+      const escapedReplacement = generateString('new longer value', existing.raw);
+      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      
+      // Should update end column to reflect new length
+      expect(result.loc.start).toEqual({ line: 1, column: 10 });
+      expect(result.loc.end.line).toBe(1);
+      expect(result.loc.end.column).toBe(10 + result.raw.length);
+      expect(result.raw).toBe('"""new longer value"""');
+    });
+
+    test('should update location for multiline string with leading newline', () => {
+      const existing = createStringNode('"""\nold\nvalue"""', 'old\nvalue');
+      existing.loc = { start: { line: 1, column: 10 }, end: { line: 3, column: 3 } };
+      
+      const escapedReplacement = generateString('new\nmultiline\nvalue', existing.raw);
+      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      
+      // Should update end line based on number of newlines
+      expect(result.loc.start).toEqual({ line: 1, column: 10 });
+      expect(result.loc.end.line).toBe(4); // start line (1) + 3 newlines
+      expect(result.loc.end.column).toBe(3); // length of delimiter
+    });
+
+    test('should handle location tracking when value changes from short to long', () => {
+      const existing = createStringNode('"""a"""', 'a');
+      existing.loc = { start: { line: 5, column: 0 }, end: { line: 5, column: 7 } };
+      
+      const escapedReplacement = generateString('much longer replacement value', existing.raw);
+      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      
+      expect(result.loc.start).toEqual({ line: 5, column: 0 });
+      expect(result.loc.end).toEqual({ line: 5, column: result.raw.length });
+      expect(result.raw).toBe('"""much longer replacement value"""');
+    });
+
+    test('should handle location tracking when value changes from long to short', () => {
+      const existing = createStringNode('"""very long original value"""', 'very long original value');
+      existing.loc = { start: { line: 2, column: 5 }, end: { line: 2, column: 35 } };
+      
+      const escapedReplacement = generateString('x', existing.raw);
+      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      
+      expect(result.loc.start).toEqual({ line: 2, column: 5 });
+      expect(result.loc.end).toEqual({ line: 2, column: 5 + result.raw.length });
+      expect(result.raw).toBe('"""x"""');
+    });
+
+    test('should handle CRLF line counting for location tracking', () => {
+      const existing = createStringNode('"""\r\nold\r\nvalue"""', 'old\r\nvalue');
+      existing.loc = { start: { line: 1, column: 0 }, end: { line: 3, column: 3 } };
+      
+      const escapedReplacement = generateString('new\r\nvalue', existing.raw);
+      const result = formatMultilineStringReplacement(existing, escapedReplacement);
+      
+      // Should count CRLF as line breaks
+      expect(result.loc.start).toEqual({ line: 1, column: 0 });
+      expect(result.loc.end.line).toBe(3); // start line (1) + 2 CRLF
+      expect(result.loc.end.column).toBe(3);
+    });
+  });
 });

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -140,14 +140,51 @@ export function generateKey(value: string[]): Key {
     value
   };
 }
-
+/**
+ * Generates a new String node, preserving multiline format if existingRaw is provided.
+ *
+ * @param value - The string value.
+ * @param existingRaw - The existing raw string to determine multiline format (optional).
+ * @returns A new String node.
+ */
 export function generateString(value: string, existingRaw?: string): String {
   let raw: string;
   
   if (existingRaw && isMultilineString(existingRaw)) {
-    // Preserve multiline format - escape any triple quotes in the value
-    const escaped = value.replace(/"""/g, '\\"""');
-    raw = `"""${escaped}"""`;
+    // Preserve multiline format
+    const isLiteral = existingRaw.startsWith("'''");
+    const delimiter = isLiteral ? "'''" : '"""';
+    
+    // Detect newline character from existing raw
+    const newlineChar = existingRaw.includes('\r\n') ? '\r\n' : '\n';
+    const hasLeadingNewline = existingRaw.startsWith(`${delimiter}${newlineChar}`);
+    
+    let escaped: string;
+    if (isLiteral) {
+      // Literal strings: only escape triple single quotes
+      escaped = value.replace(/'''/g, "''\\''");
+    } else {
+      // Basic multiline strings: escape backslashes, control characters, and triple quotes
+      escaped = value
+        .replace(/\\/g, '\\\\')  // Escape backslashes first
+        .replace(/\x08/g, '\\b') // Backspace (U+0008)
+        .replace(/\f/g, '\\f')   // Form feed (U+000C)
+        .replace(/\t/g, '\\t')   // Tab (U+0009)
+        .replace(/[\x00-\x07\x0B\x0E-\x1F\x7F]/g, (char) => {
+          // Escape other control characters
+          const code = char.charCodeAt(0);
+          return '\\u' + code.toString(16).padStart(4, '0').toUpperCase();
+        })
+        // Escape triple quotes safely: two literal quotes + escaped quote
+        .replace(/"""/g, '""\\\"');
+    }
+    
+    // Format with or without leading newline based on original
+    if (hasLeadingNewline) {
+      raw = `${delimiter}${newlineChar}${escaped}${delimiter}`;
+    } else {
+      raw = `${delimiter}${escaped}${delimiter}`;
+    }
   } else {
     raw = JSON.stringify(value);
   }

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -164,7 +164,7 @@ export function generateString(value: string, existingRaw?: string): String {
     // Detect newline character from existing raw
     const newlineChar = existingRaw.includes('\r\n') ? '\r\n' : '\n';
     const hasLeadingNewline = existingRaw.startsWith(`${delimiter}${newlineChar}`) || 
-                               (existingRaw.startsWith("'''") && !isLiteral && existingRaw.includes('\n'));
+                               ((existingRaw.startsWith("'''\n") || existingRaw.startsWith("'''\r\n")) && !isLiteral);
     
     let escaped: string;
     if (isLiteral) {

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -152,17 +152,24 @@ export function generateString(value: string, existingRaw?: string): String {
   
   if (existingRaw && isMultilineString(existingRaw)) {
     // Preserve multiline format
-    const isLiteral = existingRaw.startsWith("'''");
+    let isLiteral = existingRaw.startsWith("'''");
+    
+    // Literal strings cannot contain ''' - convert to basic string if needed
+    if (isLiteral && value.includes("'''")) {
+      isLiteral = false;
+    }
+    
     const delimiter = isLiteral ? "'''" : '"""';
     
     // Detect newline character from existing raw
     const newlineChar = existingRaw.includes('\r\n') ? '\r\n' : '\n';
-    const hasLeadingNewline = existingRaw.startsWith(`${delimiter}${newlineChar}`);
+    const hasLeadingNewline = existingRaw.startsWith(`${delimiter}${newlineChar}`) || 
+                               (existingRaw.startsWith("'''") && !isLiteral && existingRaw.includes('\n'));
     
     let escaped: string;
     if (isLiteral) {
-      // Literal strings: only escape triple single quotes
-      escaped = value.replace(/'''/g, "''\\''");
+      // Literal strings: no escaping needed (we already checked for ''' above)
+      escaped = value;
     } else {
       // Basic multiline strings: escape backslashes, control characters, and triple quotes
       escaped = value

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -22,6 +22,7 @@ import { zero, cloneLocation, clonePosition } from './location';
 import { LocalDate } from './parse-toml';
 import { TomlFormat } from './toml-format';
 import { shiftNode } from './writer';
+import { isMultilineString } from './utils';
 
 /**
  * Generates a new TOML document node.
@@ -140,8 +141,16 @@ export function generateKey(value: string[]): Key {
   };
 }
 
-export function generateString(value: string): String {
-  const raw = JSON.stringify(value);
+export function generateString(value: string, existingRaw?: string): String {
+  let raw: string;
+  
+  if (existingRaw && isMultilineString(existingRaw)) {
+    // Preserve multiline format - escape any triple quotes in the value
+    const escaped = value.replace(/"""/g, '\\"""');
+    raw = `"""${escaped}"""`;
+  } else {
+    raw = JSON.stringify(value);
+  }
 
   return {
     type: NodeType.String,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -83,3 +83,12 @@ export function merge<TValue>(target: TValue[], values: TValue[]) {
     target[original_length + i] = values[i];
   }
 }
+
+/**
+ * Checks if a string is a multiline string (starts with """ or ''')
+ * @param raw The raw string value including quotes
+ * @returns true if the string is multiline, false otherwise
+ */
+export function isMultilineString(raw: string): boolean {
+  return raw.startsWith('"""') || raw.startsWith("'''");
+}

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -78,23 +78,27 @@ export function replace(root: Root, parent: TreeNode, existing: TreeNode, replac
       
       const newlineChar = existing.raw.includes('\r\n') ? '\r\n' : '\n';
       
-      // Check if the original has newlines immediately after """ and before """
-      // Pattern: """<newline>content<newline>"""
+      // According to TOML spec, only the first newline after """ is trimmed during parsing.
+      // All other newlines (including trailing ones) are significant and part of the value.
+      // We need to preserve the leading newline formatting if it was present in the original.
       const hasLeadingNewline = existing.raw.startsWith(`"""${newlineChar}`) || existing.raw.startsWith(`'''${newlineChar}`);
-      const hasTrailingNewline = existing.raw.endsWith(`${newlineChar}"""`) || existing.raw.endsWith(`${newlineChar}'''`);
       
       let formattedRaw: string;
-      if (hasLeadingNewline && hasTrailingNewline) {
-        formattedRaw = `"""${newlineChar}${escaped}${newlineChar}"""`;
+      if (hasLeadingNewline) {
+        // Preserve the leading newline format. The escaped value already contains any trailing newlines.
+        formattedRaw = `"""${newlineChar}${escaped}"""`;
         
-        // Update location to account for the 3 lines (opening """\n, content, closing \n""")
+        // Count the number of lines in the formatted raw string
+        const lineCount = (formattedRaw.match(new RegExp(newlineChar === '\r\n' ? '\\r\\n' : '\\n', 'g')) || []).length;
+        
+        // Update location to account for the lines
         replacement = {
           ...replacement,
           raw: formattedRaw,
           loc: {
             start: existing.loc.start,
             end: {
-              line: existing.loc.start.line + 2, // 3 lines total (0, 1, 2)
+              line: existing.loc.start.line + lineCount,
               column: 3 // length of """
             }
           }

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -77,7 +77,7 @@ const getExitOffsets = (root: Root) => {
  * @param replacement - The replacement string node (already fully formatted by generateString)
  * @returns The replacement string node with updated location information
  */
-export function formatMultilineStringReplacement(existing: String, replacement: String): String {
+export function fixStringLocation(existing: String, replacement: String): String {
   if (!isMultilineString(replacement.raw)) {
     return replacement;
   }
@@ -119,8 +119,7 @@ export function replace(root: Root, parent: TreeNode, existing: TreeNode, replac
   if (isString(existing) && isString(replacement)) {
     // Regenerate the replacement with proper escaping based on existing format
     const escapedReplacement = generateString(replacement.value, existing.raw);
-    // Then format it to preserve leading newlines and update location
-    replacement = formatMultilineStringReplacement(existing, escapedReplacement);
+    replacement = fixStringLocation(existing, escapedReplacement);
   }
   
   // Special handling for DateTime nodes to preserve original format by editing replacement values

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -75,10 +75,37 @@ export function replace(root: Root, parent: TreeNode, existing: TreeNode, replac
     // If the existing string is multiline, preserve that format
     if (isMultilineString(existing.raw)) {
       const escaped = replacement.value.replace(/"""/g, '\\"""');
-      replacement = {
-        ...replacement,
-        raw: `"""${escaped}"""`
-      } as String;
+      
+      const newlineChar = existing.raw.includes('\r\n') ? '\r\n' : '\n';
+      
+      // Check if the original has newlines immediately after """ and before """
+      // Pattern: """<newline>content<newline>"""
+      const hasLeadingNewline = existing.raw.startsWith(`"""${newlineChar}`) || existing.raw.startsWith(`'''${newlineChar}`);
+      const hasTrailingNewline = existing.raw.endsWith(`${newlineChar}"""`) || existing.raw.endsWith(`${newlineChar}'''`);
+      
+      let formattedRaw: string;
+      if (hasLeadingNewline && hasTrailingNewline) {
+        formattedRaw = `"""${newlineChar}${escaped}${newlineChar}"""`;
+        
+        // Update location to account for the 3 lines (opening """\n, content, closing \n""")
+        replacement = {
+          ...replacement,
+          raw: formattedRaw,
+          loc: {
+            start: existing.loc.start,
+            end: {
+              line: existing.loc.start.line + 2, // 3 lines total (0, 1, 2)
+              column: 3 // length of """
+            }
+          }
+        } as String;
+      } else {
+        formattedRaw = `"""${escaped}"""`;
+        replacement = {
+          ...replacement,
+          raw: formattedRaw
+        } as String;
+      }
     }
   }
   

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -33,6 +33,7 @@ import {
 import { Span, getSpan, clonePosition } from './location';
 import { last, isMultilineString } from './utils';
 import traverse from './traverse';
+import { generateString } from './generate';
 
 ////////////////////////////////////////
 // The purpose of this file is to provide a way to modify the AST
@@ -69,64 +70,26 @@ const getExitOffsets = (root: Root) => {
 };
 
 /**
- * Formats a replacement string value to preserve multiline string format.
- * Handles both basic multiline strings (""") and literal multiline strings (''').
+ * Updates location information for a replacement string to match the existing string's position.
+ * The actual formatting and escaping is done by generateString().
  * 
- * @param existing - The existing string node with the original format
- * @param replacement - The replacement string node with the new value
- * @returns The replacement string node with updated raw value and location, or the original replacement if not multiline
+ * @param existing - The existing string node with the original format and location
+ * @param replacement - The replacement string node (already fully formatted by generateString)
+ * @returns The replacement string node with updated location information
  */
 export function formatMultilineStringReplacement(existing: String, replacement: String): String {
-  if (!isMultilineString(existing.raw)) {
+  if (!isMultilineString(replacement.raw)) {
     return replacement;
   }
 
-  // Determine if this is a literal multiline string (''') or basic multiline string (""")
-  const isLiteral = existing.raw.startsWith("'''");
+  // Detect newline character to count lines correctly
+  const newlineChar = replacement.raw.includes('\r\n') ? '\r\n' : '\n';
+  const lineCount = (replacement.raw.match(new RegExp(newlineChar === '\r\n' ? '\\r\\n' : '\\n', 'g')) || []).length;
   
-  let escaped: string = replacement.value;
-  if (isLiteral) {
-    // Literal strings: no escaping needed except for triple single quotes
-    escaped = replacement.value.replace(/'''/g, "''\\''");
-  } else {
-    // Basic multiline strings: need to escape backslashes and control characters (like basic strings)
-    // Escape backslashes first, then control characters, then triple quotes
-    escaped = replacement.value
-      .replace(/\\/g, '\\\\')  // Escape backslashes first
-      .replace(/\x08/g, '\\b') // Backspace (U+0008)
-      .replace(/\f/g, '\\f')   // Form feed (U+000C)
-      .replace(/\t/g, '\\t')   // Tab (U+0009)
-      .replace(/[\x00-\x07\x0B\x0E-\x1F\x7F]/g, (char) => {
-        // Escape other control characters (U+0000-U+0007, U+000B, U+000E-U+001F, U+007F)
-        // Note: \n (U+000A) and \r (U+000D) are allowed in multiline strings, so we exclude them
-        const code = char.charCodeAt(0);
-        return '\\u' + code.toString(16).padStart(4, '0').toUpperCase();
-      })
-      // Escape triple quotes safely: two literal quotes + escaped quote
-      // This prevents issues with 4+ consecutive quotes ("""" would become ""\"  instead of \""")
-      .replace(/"""/g, '""\\\"');
-  }
-  
-  const newlineChar = existing.raw.includes('\r\n') ? '\r\n' : '\n';
-  
-  // According to TOML spec, only the first newline after delimiter is trimmed during parsing.
-  // All other newlines (including trailing ones) are significant and part of the value.
-  // We need to preserve the leading newline formatting if it was present in the original.
-  const delimiter = isLiteral ? "'''" : '"""';
-  const hasLeadingNewline = existing.raw.startsWith(`${delimiter}${newlineChar}`);
-  
-  let formattedRaw: string;
-  if (hasLeadingNewline) {
-    // Preserve the leading newline format. The escaped value already contains any trailing newlines.
-    formattedRaw = `${delimiter}${newlineChar}${escaped}${delimiter}`;
-    
-    // Count the number of lines in the formatted raw string
-    const lineCount = (formattedRaw.match(new RegExp(newlineChar === '\r\n' ? '\\r\\n' : '\\n', 'g')) || []).length;
-    
-    // Update location to account for the lines
+  // Update location to match existing position and account for multiple lines
+  if (lineCount > 0) {
     return {
       ...replacement,
-      raw: formattedRaw,
       loc: {
         start: existing.loc.start,
         end: {
@@ -136,10 +99,15 @@ export function formatMultilineStringReplacement(existing: String, replacement: 
       }
     } as String;
   } else {
-    formattedRaw = `${delimiter}${escaped}${delimiter}`;
     return {
       ...replacement,
-      raw: formattedRaw
+      loc: {
+        start: existing.loc.start,
+        end: {
+          line: existing.loc.start.line,
+          column: existing.loc.start.column + replacement.raw.length
+        }
+      }
     } as String;
   }
 }
@@ -149,7 +117,10 @@ export function replace(root: Root, parent: TreeNode, existing: TreeNode, replac
   
   // Special handling for String nodes to preserve multiline format by editing replacement values
   if (isString(existing) && isString(replacement)) {
-    replacement = formatMultilineStringReplacement(existing, replacement);
+    // Regenerate the replacement with proper escaping based on existing format
+    const escapedReplacement = generateString(replacement.value, existing.raw);
+    // Then format it to preserve leading newlines and update location
+    replacement = formatMultilineStringReplacement(existing, escapedReplacement);
   }
   
   // Special handling for DateTime nodes to preserve original format by editing replacement values

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -74,19 +74,42 @@ export function replace(root: Root, parent: TreeNode, existing: TreeNode, replac
   if (isString(existing) && isString(replacement)) {
     // If the existing string is multiline, preserve that format
     if (isMultilineString(existing.raw)) {
-      const escaped = replacement.value.replace(/"""/g, '\\"""');
+      // Determine if this is a literal multiline string (''') or basic multiline string (""")
+      const isLiteral = existing.raw.startsWith("'''");
+      
+      let escaped: string;
+      if (isLiteral) {
+        // Literal strings: no escaping needed except for triple single quotes
+        escaped = replacement.value.replace(/'''/g, "''\\''");
+      } else {
+        // Basic multiline strings: need to escape backslashes and control characters (like basic strings)
+        // Escape backslashes first, then control characters, then triple quotes
+        escaped = replacement.value
+          .replace(/\\/g, '\\\\')  // Escape backslashes first
+          .replace(/\x08/g, '\\b') // Backspace (U+0008)
+          .replace(/\f/g, '\\f')   // Form feed (U+000C)
+          .replace(/\t/g, '\\t')   // Tab (U+0009)
+          .replace(/[\x00-\x07\x0B\x0E-\x1F\x7F]/g, (char) => {
+            // Escape other control characters (U+0000-U+0007, U+000B, U+000E-U+001F, U+007F)
+            // Note: \n (U+000A) and \r (U+000D) are allowed in multiline strings, so we exclude them
+            const code = char.charCodeAt(0);
+            return '\\u' + code.toString(16).padStart(4, '0').toUpperCase();
+          })
+          .replace(/"""/g, '\\"""');  // Escape triple quotes
+      }
       
       const newlineChar = existing.raw.includes('\r\n') ? '\r\n' : '\n';
       
-      // According to TOML spec, only the first newline after """ is trimmed during parsing.
+      // According to TOML spec, only the first newline after delimiter is trimmed during parsing.
       // All other newlines (including trailing ones) are significant and part of the value.
       // We need to preserve the leading newline formatting if it was present in the original.
-      const hasLeadingNewline = existing.raw.startsWith(`"""${newlineChar}`) || existing.raw.startsWith(`'''${newlineChar}`);
+      const delimiter = isLiteral ? "'''" : '"""';
+      const hasLeadingNewline = existing.raw.startsWith(`${delimiter}${newlineChar}`);
       
       let formattedRaw: string;
       if (hasLeadingNewline) {
         // Preserve the leading newline format. The escaped value already contains any trailing newlines.
-        formattedRaw = `"""${newlineChar}${escaped}"""`;
+        formattedRaw = `${delimiter}${newlineChar}${escaped}${delimiter}`;
         
         // Count the number of lines in the formatted raw string
         const lineCount = (formattedRaw.match(new RegExp(newlineChar === '\r\n' ? '\\r\\n' : '\\n', 'g')) || []).length;
@@ -99,12 +122,12 @@ export function replace(root: Root, parent: TreeNode, existing: TreeNode, replac
             start: existing.loc.start,
             end: {
               line: existing.loc.start.line + lineCount,
-              column: 3 // length of """
+              column: 3 // length of delimiter
             }
           }
         } as String;
       } else {
-        formattedRaw = `"""${escaped}"""`;
+        formattedRaw = `${delimiter}${escaped}${delimiter}`;
         replacement = {
           ...replacement,
           raw: formattedRaw

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -67,76 +67,92 @@ const getExitOffsets = (root: Root) => {
   }
   return exit_offsets.get(root)!;
 };
+
+/**
+ * Formats a replacement string value to preserve multiline string format.
+ * Handles both basic multiline strings (""") and literal multiline strings (''').
+ * 
+ * @param existing - The existing string node with the original format
+ * @param replacement - The replacement string node with the new value
+ * @returns The replacement string node with updated raw value and location, or the original replacement if not multiline
+ */
+export function formatMultilineStringReplacement(existing: String, replacement: String): String {
+  if (!isMultilineString(existing.raw)) {
+    return replacement;
+  }
+
+  // Determine if this is a literal multiline string (''') or basic multiline string (""")
+  const isLiteral = existing.raw.startsWith("'''");
+  
+  let escaped: string = replacement.value;
+  if (isLiteral) {
+    // Literal strings: no escaping needed except for triple single quotes
+    escaped = replacement.value.replace(/'''/g, "''\\''");
+  } else {
+    // Basic multiline strings: need to escape backslashes and control characters (like basic strings)
+    // Escape backslashes first, then control characters, then triple quotes
+    escaped = replacement.value
+      .replace(/\\/g, '\\\\')  // Escape backslashes first
+      .replace(/\x08/g, '\\b') // Backspace (U+0008)
+      .replace(/\f/g, '\\f')   // Form feed (U+000C)
+      .replace(/\t/g, '\\t')   // Tab (U+0009)
+      .replace(/[\x00-\x07\x0B\x0E-\x1F\x7F]/g, (char) => {
+        // Escape other control characters (U+0000-U+0007, U+000B, U+000E-U+001F, U+007F)
+        // Note: \n (U+000A) and \r (U+000D) are allowed in multiline strings, so we exclude them
+        const code = char.charCodeAt(0);
+        return '\\u' + code.toString(16).padStart(4, '0').toUpperCase();
+      })
+      // Escape triple quotes safely: two literal quotes + escaped quote
+      // This prevents issues with 4+ consecutive quotes ("""" would become ""\"  instead of \""")
+      .replace(/"""/g, '""\\\"');
+  }
+  
+  const newlineChar = existing.raw.includes('\r\n') ? '\r\n' : '\n';
+  
+  // According to TOML spec, only the first newline after delimiter is trimmed during parsing.
+  // All other newlines (including trailing ones) are significant and part of the value.
+  // We need to preserve the leading newline formatting if it was present in the original.
+  const delimiter = isLiteral ? "'''" : '"""';
+  const hasLeadingNewline = existing.raw.startsWith(`${delimiter}${newlineChar}`);
+  
+  let formattedRaw: string;
+  if (hasLeadingNewline) {
+    // Preserve the leading newline format. The escaped value already contains any trailing newlines.
+    formattedRaw = `${delimiter}${newlineChar}${escaped}${delimiter}`;
+    
+    // Count the number of lines in the formatted raw string
+    const lineCount = (formattedRaw.match(new RegExp(newlineChar === '\r\n' ? '\\r\\n' : '\\n', 'g')) || []).length;
+    
+    // Update location to account for the lines
+    return {
+      ...replacement,
+      raw: formattedRaw,
+      loc: {
+        start: existing.loc.start,
+        end: {
+          line: existing.loc.start.line + lineCount,
+          column: 3 // length of delimiter
+        }
+      }
+    } as String;
+  } else {
+    formattedRaw = `${delimiter}${escaped}${delimiter}`;
+    return {
+      ...replacement,
+      raw: formattedRaw
+    } as String;
+  }
+}
+
 //TODO: Add getOffsets function to get all offsets contained in the tree
 export function replace(root: Root, parent: TreeNode, existing: TreeNode, replacement: TreeNode) {
   
-  // Special handling for String nodes to preserve multiline format
+  // Special handling for String nodes to preserve multiline format by editing replacement values
   if (isString(existing) && isString(replacement)) {
-    // If the existing string is multiline, preserve that format
-    if (isMultilineString(existing.raw)) {
-      // Determine if this is a literal multiline string (''') or basic multiline string (""")
-      const isLiteral = existing.raw.startsWith("'''");
-      
-      let escaped: string;
-      if (isLiteral) {
-        // Literal strings: no escaping needed except for triple single quotes
-        escaped = replacement.value.replace(/'''/g, "''\\''");
-      } else {
-        // Basic multiline strings: need to escape backslashes and control characters (like basic strings)
-        // Escape backslashes first, then control characters, then triple quotes
-        escaped = replacement.value
-          .replace(/\\/g, '\\\\')  // Escape backslashes first
-          .replace(/\x08/g, '\\b') // Backspace (U+0008)
-          .replace(/\f/g, '\\f')   // Form feed (U+000C)
-          .replace(/\t/g, '\\t')   // Tab (U+0009)
-          .replace(/[\x00-\x07\x0B\x0E-\x1F\x7F]/g, (char) => {
-            // Escape other control characters (U+0000-U+0007, U+000B, U+000E-U+001F, U+007F)
-            // Note: \n (U+000A) and \r (U+000D) are allowed in multiline strings, so we exclude them
-            const code = char.charCodeAt(0);
-            return '\\u' + code.toString(16).padStart(4, '0').toUpperCase();
-          })
-          .replace(/"""/g, '\\"""');  // Escape triple quotes
-      }
-      
-      const newlineChar = existing.raw.includes('\r\n') ? '\r\n' : '\n';
-      
-      // According to TOML spec, only the first newline after delimiter is trimmed during parsing.
-      // All other newlines (including trailing ones) are significant and part of the value.
-      // We need to preserve the leading newline formatting if it was present in the original.
-      const delimiter = isLiteral ? "'''" : '"""';
-      const hasLeadingNewline = existing.raw.startsWith(`${delimiter}${newlineChar}`);
-      
-      let formattedRaw: string;
-      if (hasLeadingNewline) {
-        // Preserve the leading newline format. The escaped value already contains any trailing newlines.
-        formattedRaw = `${delimiter}${newlineChar}${escaped}${delimiter}`;
-        
-        // Count the number of lines in the formatted raw string
-        const lineCount = (formattedRaw.match(new RegExp(newlineChar === '\r\n' ? '\\r\\n' : '\\n', 'g')) || []).length;
-        
-        // Update location to account for the lines
-        replacement = {
-          ...replacement,
-          raw: formattedRaw,
-          loc: {
-            start: existing.loc.start,
-            end: {
-              line: existing.loc.start.line + lineCount,
-              column: 3 // length of delimiter
-            }
-          }
-        } as String;
-      } else {
-        formattedRaw = `${delimiter}${escaped}${delimiter}`;
-        replacement = {
-          ...replacement,
-          raw: formattedRaw
-        } as String;
-      }
-    }
+    replacement = formatMultilineStringReplacement(existing, replacement);
   }
   
-  // Special handling for DateTime nodes to preserve original format
+  // Special handling for DateTime nodes to preserve original format by editing replacement values
   if (isDateTime(existing) && isDateTime(replacement)) {
     // Analyze the original raw format and create a properly formatted replacement
     const originalRaw = existing.raw;

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -26,10 +26,12 @@ import {
   Block,
   isBlock,
   DateTime,
-  isDateTime
+  isDateTime,
+  String,
+  isString
 } from './ast';
 import { Span, getSpan, clonePosition } from './location';
-import { last } from './utils';
+import { last, isMultilineString } from './utils';
 import traverse from './traverse';
 
 ////////////////////////////////////////
@@ -67,6 +69,18 @@ const getExitOffsets = (root: Root) => {
 };
 //TODO: Add getOffsets function to get all offsets contained in the tree
 export function replace(root: Root, parent: TreeNode, existing: TreeNode, replacement: TreeNode) {
+  
+  // Special handling for String nodes to preserve multiline format
+  if (isString(existing) && isString(replacement)) {
+    // If the existing string is multiline, preserve that format
+    if (isMultilineString(existing.raw)) {
+      const escaped = replacement.value.replace(/"""/g, '\\"""');
+      replacement = {
+        ...replacement,
+        raw: `"""${escaped}"""`
+      } as String;
+    }
+  }
   
   // Special handling for DateTime nodes to preserve original format
   if (isDateTime(existing) && isDateTime(replacement)) {


### PR DESCRIPTION
This pull request improves the handling of multiline TOML strings to ensure their formatting is preserved when patching or generating TOML documents. The changes make sure that we preserve the string as a triple-quoted string even if the string has no extra newlines except the one and the start which are ignored per TOML spec:

> A newline immediately following the opening delimiter will be trimmed. All other whitespace and newline characters remain intact.

[Source](https://toml.io/en/v1.1.0#string:~:text=Multi%2Dline%20basic%20strings%20are%20surrounded%20by%20three%20quotation%20marks%20on%20each%20side%20and%20allow%20newlines.%20A%20newline%20immediately%20following%20the%20opening%20delimiter%20will%20be%20trimmed.%20All%20other%20whitespace%20and%20newline%20characters%20remain%20intact.)