### PR TITLE
refactor: Avoid circular reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed 
+- Remove circular reference warning ([#90](https://github.com/DecimalTurn/toml-patch/pull/90))
+
 ## [0.5.1] - 2026-01-18
 
 ### Added

--- a/src/__tests__/writer.test.ts
+++ b/src/__tests__/writer.test.ts
@@ -1,4 +1,4 @@
-import { insert, applyWrites, fixStringLocation } from '../writer';
+import { insert, applyWrites } from '../writer';
 import toTOML from '../to-toml';
 import {
   generateInlineArray,
@@ -58,7 +58,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"""old"""', 'old');
       const escapedReplacement = generateString('Three quotes: """', existing.raw);
       
-      const result = fixStringLocation(existing, escapedReplacement);
+      const result = escapedReplacement;
       
       // Three quotes should be escaped as: two literal quotes + escaped quote
       expect(result.raw).toBe('"""Three quotes: ""\\""""');
@@ -68,7 +68,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"""old"""', 'old');
       const escapedReplacement = generateString('Four quotes: """"', existing.raw);
       
-      const result = fixStringLocation(existing, escapedReplacement);
+      const result = escapedReplacement;
       
       // First three quotes escaped as ""\" and fourth remains literal
       expect(result.raw).toBe('"""Four quotes: ""\\"""""');
@@ -78,7 +78,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"""old"""', 'old');
       const escapedReplacement = generateString('Five quotes: """""', existing.raw);
       
-      const result = fixStringLocation(existing, escapedReplacement);
+      const result = escapedReplacement;
       
       // Pattern: ""\" + remaining quotes
       expect(result.raw).toBe('"""Five quotes: ""\\""""""');
@@ -88,7 +88,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"""old"""', 'old');
       const escapedReplacement = generateString('Six quotes: """"""', existing.raw);
       
-      const result = fixStringLocation(existing, escapedReplacement);
+      const result = escapedReplacement;
       
       // Two sets of three quotes: ""\" + """ (second set becomes ""\")
       // Input: """""" -> First three (""") becomes ""\", next three (""") becomes ""\"
@@ -99,7 +99,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"""old"""', 'old');
       const escapedReplacement = generateString('First: """ and second: """', existing.raw);
       
-      const result = fixStringLocation(existing, escapedReplacement);
+      const result = escapedReplacement;
       
       expect(result.raw).toBe('"""First: ""\\" and second: ""\\""""');
     });
@@ -108,7 +108,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"""old"""', 'old');
       const escapedReplacement = generateString('Path: C:\\Data and quotes: """', existing.raw);
       
-      const result = fixStringLocation(existing, escapedReplacement);
+      const result = escapedReplacement;
       
       // Backslashes escaped first, then quotes
       expect(result.raw).toBe('"""Path: C:\\\\Data and quotes: ""\\""""');
@@ -118,7 +118,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"""old"""', 'old');
       const escapedReplacement = generateString('One " or two "" quotes', existing.raw);
       
-      const result = fixStringLocation(existing, escapedReplacement);
+      const result = escapedReplacement;
       
       // Single and double quotes are allowed unescaped
       expect(result.raw).toBe('"""One " or two "" quotes"""');
@@ -128,7 +128,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"""old"""', 'old');
       const escapedReplacement = generateString('Tab:\there Newline:\nallowed', existing.raw);
       
-      const result = fixStringLocation(existing, escapedReplacement);
+      const result = escapedReplacement;
       
       // Tab escaped, newlines allowed in multiline strings
       expect(result.raw).toBe('"""Tab:\\there Newline:\nallowed"""');
@@ -140,7 +140,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode("'''old'''", 'old');
       const escapedReplacement = generateString("Three quotes: '''", existing.raw);
       
-      const result = fixStringLocation(existing, escapedReplacement);
+      const result = escapedReplacement;
       
       // Should convert from literal (''') to basic (""")
       // Note: ''' doesn't need escaping in basic strings
@@ -151,7 +151,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode("'''old'''", 'old');
       const escapedReplacement = generateString("Path: C:\\Data\\Files", existing.raw);
       
-      const result = fixStringLocation(existing, escapedReplacement);
+      const result = escapedReplacement;
       
       // Backslashes are literal in ''' strings
       expect(result.raw).toBe("'''Path: C:\\Data\\Files'''");
@@ -163,7 +163,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"regular"', 'regular');
       const replacement = createStringNode('"new"', 'new value');
       
-      const result = fixStringLocation(existing, replacement);
+      const result = replacement;
       
       // Should return the original replacement unchanged
       expect(result).toBe(replacement);
@@ -175,7 +175,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"""\nold"""', 'old');
       const escapedReplacement = generateString('new value', existing.raw);
       
-      const result = fixStringLocation(existing, escapedReplacement);
+      const result = escapedReplacement;
       
       expect(result.raw).toBe('"""\nnew value"""');
     });
@@ -184,7 +184,7 @@ describe('formatMultilineStringReplacement', () => {
       const existing = createStringNode('"""\r\nold"""', 'old');
       const escapedReplacement = generateString('new value', existing.raw);
       
-      const result = fixStringLocation(existing, escapedReplacement);
+      const result = escapedReplacement;
       
       expect(result.raw).toBe('"""\r\nnew value"""');
     });
@@ -197,12 +197,12 @@ describe('formatMultilineStringReplacement', () => {
       existing.loc = { start: { line: 1, column: 10 }, end: { line: 1, column: 19 } };
       
       const escapedReplacement = generateString('new longer value', existing.raw);
-      const result = fixStringLocation(existing, escapedReplacement);
+      const result = escapedReplacement;
       
-      // Should update end column to reflect new length
-      expect(result.loc.start).toEqual({ line: 1, column: 10 });
+      // generateString returns base location (not adjusted to existing position - that's done by shiftNode in replace)
+      expect(result.loc.start).toEqual({ line: 1, column: 0 });
       expect(result.loc.end.line).toBe(1);
-      expect(result.loc.end.column).toBe(10 + result.raw.length);
+      expect(result.loc.end.column).toBe(result.raw.length);
       expect(result.raw).toBe('"""new longer value"""');
     });
 
@@ -211,11 +211,11 @@ describe('formatMultilineStringReplacement', () => {
       existing.loc = { start: { line: 1, column: 10 }, end: { line: 3, column: 3 } };
       
       const escapedReplacement = generateString('new\nmultiline\nvalue', existing.raw);
-      const result = fixStringLocation(existing, escapedReplacement);
+      const result = escapedReplacement;
       
-      // Should update end line based on number of newlines
-      expect(result.loc.start).toEqual({ line: 1, column: 10 });
-      expect(result.loc.end.line).toBe(4); // start line (1) + 3 newlines
+      // generateString returns base location (not adjusted to existing position - that's done by shiftNode in replace)
+      expect(result.loc.start).toEqual({ line: 1, column: 0 });
+      expect(result.loc.end.line).toBe(4); // base line (1) + 3 newlines
       expect(result.loc.end.column).toBe(3); // length of delimiter
     });
 
@@ -224,10 +224,11 @@ describe('formatMultilineStringReplacement', () => {
       existing.loc = { start: { line: 5, column: 0 }, end: { line: 5, column: 7 } };
       
       const escapedReplacement = generateString('much longer replacement value', existing.raw);
-      const result = fixStringLocation(existing, escapedReplacement);
+      const result = escapedReplacement;
       
-      expect(result.loc.start).toEqual({ line: 5, column: 0 });
-      expect(result.loc.end).toEqual({ line: 5, column: result.raw.length });
+      // generateString returns base location
+      expect(result.loc.start).toEqual({ line: 1, column: 0 });
+      expect(result.loc.end).toEqual({ line: 1, column: result.raw.length });
       expect(result.raw).toBe('"""much longer replacement value"""');
     });
 
@@ -236,10 +237,11 @@ describe('formatMultilineStringReplacement', () => {
       existing.loc = { start: { line: 2, column: 5 }, end: { line: 2, column: 35 } };
       
       const escapedReplacement = generateString('x', existing.raw);
-      const result = fixStringLocation(existing, escapedReplacement);
+      const result = escapedReplacement;
       
-      expect(result.loc.start).toEqual({ line: 2, column: 5 });
-      expect(result.loc.end).toEqual({ line: 2, column: 5 + result.raw.length });
+      // generateString returns base location
+      expect(result.loc.start).toEqual({ line: 1, column: 0 });
+      expect(result.loc.end).toEqual({ line: 1, column: result.raw.length });
       expect(result.raw).toBe('"""x"""');
     });
 
@@ -248,11 +250,11 @@ describe('formatMultilineStringReplacement', () => {
       existing.loc = { start: { line: 1, column: 0 }, end: { line: 3, column: 3 } };
       
       const escapedReplacement = generateString('new\r\nvalue', existing.raw);
-      const result = fixStringLocation(existing, escapedReplacement);
+      const result = escapedReplacement;
       
-      // Should count CRLF as line breaks
+      // generateString returns base location and counts CRLF as line breaks
       expect(result.loc.start).toEqual({ line: 1, column: 0 });
-      expect(result.loc.end.line).toBe(3); // start line (1) + 2 CRLF
+      expect(result.loc.end.line).toBe(3); // base line (1) + 2 CRLF
       expect(result.loc.end.column).toBe(3);
     });
   });

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -204,6 +204,12 @@ export function generateString(value: string, existingRaw?: string): String {
   };
 }
 
+/**
+ * Generates a new Integer node.
+ *
+ * @param value - The integer value.
+ * @returns A new Integer node.
+ */
 export function generateInteger(value: number): Integer {
   const raw = value.toString();
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -196,9 +196,27 @@ export function generateString(value: string, existingRaw?: string): String {
     raw = JSON.stringify(value);
   }
 
+  // Calculate proper end location for multiline strings
+  let endLocation;
+  if (raw.includes('\r\n') || (raw.includes('\n') && !raw.includes('\r\n'))) {
+    const newlineChar = raw.includes('\r\n') ? '\r\n' : '\n';
+    const lineCount = (raw.match(new RegExp(newlineChar === '\r\n' ? '\\r\\n' : '\\n', 'g')) || []).length;
+    
+    if (lineCount > 0) {
+      endLocation = {
+        line: 1 + lineCount,
+        column: 3 // length of delimiter (""" or ''')
+      };
+    } else {
+      endLocation = { line: 1, column: raw.length };
+    }
+  } else {
+    endLocation = { line: 1, column: raw.length };
+  }
+
   return {
     type: NodeType.String,
-    loc: { start: zero(), end: { line: 1, column: raw.length } },
+    loc: { start: zero(), end: endLocation },
     raw,
     value
   };

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -22,7 +22,8 @@ import {
   InlineItem,
   AST,
   Table,
-  Value
+  Value,
+  isDateTime
 } from './ast';
 import diff, { Change, isAdd, isEdit, isRemove, isMove, isRename } from './diff';
 import findByPath, { tryFindByPath, findParent } from './find-by-path';
@@ -31,6 +32,7 @@ import { insert, replace, remove, applyWrites } from './writer';
 import { generateInlineItem, generateTable, generateString } from './generate';
 import { validate } from './validate';
 import { arrayHadTrailingCommas, tableHadTrailingCommas, resolveTomlFormat, postInlineItemRemovalAdjustment, calculateTableDepth } from './toml-format';
+import { DateFormatHelper } from './date-format';
 
 export function toDocument(ast: AST) : Document  {
   const items = [...ast];
@@ -132,18 +134,39 @@ function reorder(changes: Change[]): Change[] {
 
 /**
  * Preserves formatting from the existing node when applying it to the replacement node.
- * This includes multiline string formats, trailing commas, etc.
+ * This includes multiline string formats, trailing commas, DateTime formats, etc.
  * 
  * @param existing - The existing node with formatting to preserve
  * @param replacement - The replacement node to apply formatting to
  */
 function preserveFormatting(existing: Value, replacement: Value): void {
+  
   // Preserve multiline string format
   if (isString(existing) && isString(replacement) && isMultilineString(existing.raw)) {
     // Generate new string node with preserved multiline format
     const newString = generateString(replacement.value, existing.raw);
     replacement.raw = newString.raw;
     replacement.loc = newString.loc;
+  }
+  
+  // Preserve DateTime format
+  if (isDateTime(existing) && isDateTime(replacement)) {
+    // Analyze the original raw format and create a properly formatted replacement
+    const originalRaw = existing.raw;
+    const newValue = replacement.value;
+    
+    // Create a new date with the original format preserved
+    const formattedDate = DateFormatHelper.createDateWithOriginalFormat(newValue, originalRaw);
+    
+    // Update the replacement with the properly formatted date
+    replacement.value = formattedDate;
+    replacement.raw = formattedDate.toISOString();
+    
+    // Adjust the location information to match the new raw length
+    const lengthDiff = replacement.raw.length - originalRaw.length;
+    if (lengthDiff !== 0) {
+      replacement.loc.end.column = replacement.loc.start.column + replacement.raw.length;
+    }
   }
   
   // Preserve array trailing comma format

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -17,16 +17,18 @@ import {
   isInlineArray,
   isInlineTable,
   isInlineItem,
+  isString,
   hasItem,
   InlineItem,
   AST,
-  Table
+  Table,
+  Value
 } from './ast';
 import diff, { Change, isAdd, isEdit, isRemove, isMove, isRename } from './diff';
 import findByPath, { tryFindByPath, findParent } from './find-by-path';
-import { last, isInteger } from './utils';
+import { last, isInteger, isMultilineString } from './utils';
 import { insert, replace, remove, applyWrites } from './writer';
-import { generateInlineItem, generateTable } from './generate';
+import { generateInlineItem, generateTable, generateString } from './generate';
 import { validate } from './validate';
 import { arrayHadTrailingCommas, tableHadTrailingCommas, resolveTomlFormat, postInlineItemRemovalAdjustment, calculateTableDepth } from './toml-format';
 
@@ -126,6 +128,41 @@ function reorder(changes: Change[]): Change[] {
   
   return changes;
 
+}
+
+/**
+ * Preserves formatting from the existing node when applying it to the replacement node.
+ * This includes multiline string formats, trailing commas, etc.
+ * 
+ * @param existing - The existing node with formatting to preserve
+ * @param replacement - The replacement node to apply formatting to
+ */
+function preserveFormatting(existing: Value, replacement: Value): void {
+  // Preserve multiline string format
+  if (isString(existing) && isString(replacement) && isMultilineString(existing.raw)) {
+    // Generate new string node with preserved multiline format
+    const newString = generateString(replacement.value, existing.raw);
+    replacement.raw = newString.raw;
+    replacement.loc = newString.loc;
+  }
+  
+  // Preserve array trailing comma format
+  if (isInlineArray(existing) && isInlineArray(replacement)) {
+    const originalHadTrailingCommas = arrayHadTrailingCommas(existing);
+    if (replacement.items.length > 0) {
+      const lastItem = replacement.items[replacement.items.length - 1];
+      lastItem.comma = originalHadTrailingCommas;
+    }
+  }
+  
+  // Preserve inline table trailing comma format
+  if (isInlineTable(existing) && isInlineTable(replacement)) {
+    const originalHadTrailingCommas = tableHadTrailingCommas(existing);
+    if (replacement.items.length > 0) {
+      const lastItem = replacement.items[replacement.items.length - 1];
+      lastItem.comma = originalHadTrailingCommas;
+    }
+  }
 }
 
 /**
@@ -270,30 +307,8 @@ function applyChanges(original: Document, updated: Document, changes: Change[], 
 
       if (isKeyValue(existing) && isKeyValue(replacement)) {
         // Edit for key-value means value changes
-
-        // Special handling for arrays: preserve original trailing comma format
-        if (isInlineArray(existing.value) && isInlineArray(replacement.value)) {
-          const originalHadTrailingCommas = arrayHadTrailingCommas(existing.value);
-          const newArray = replacement.value;
-          
-          // Apply or remove trailing comma based on original format
-          if (newArray.items.length > 0) {
-            const lastItem = newArray.items[newArray.items.length - 1];
-            lastItem.comma = originalHadTrailingCommas;
-          }
-        }
-        
-        // Special handling for inline tables: preserve original trailing comma format
-        if (isInlineTable(existing.value) && isInlineTable(replacement.value)) {
-          const originalHadTrailingCommas = tableHadTrailingCommas(existing.value);
-          const newTable = replacement.value;
-          
-          // Apply or remove trailing comma based on original format
-          if (newTable.items.length > 0) {
-            const lastItem = newTable.items[newTable.items.length - 1];
-            lastItem.comma = originalHadTrailingCommas;
-          }
-        }
+        // Preserve formatting from existing value in replacement value
+        preserveFormatting(existing.value, replacement.value);
         
         parent = existing;
         existing = existing.value;

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -68,56 +68,8 @@ const getExitOffsets = (root: Root) => {
   return exit_offsets.get(root)!;
 };
 
-/**
- * Updates location information for a replacement string to match the existing string's position.
- * The actual formatting and escaping is done by generateString().
- * 
- * @param existing - The existing string node with the original format and location
- * @param replacement - The replacement string node (already fully formatted by generateString)
- * @returns The replacement string node with updated location information
- */
-export function fixStringLocation(existing: String, replacement: String): String {
-  if (!isMultilineString(replacement.raw)) {
-    return replacement;
-  }
-
-  // Detect newline character to count lines correctly
-  const newlineChar = replacement.raw.includes('\r\n') ? '\r\n' : '\n';
-  const lineCount = (replacement.raw.match(new RegExp(newlineChar === '\r\n' ? '\\r\\n' : '\\n', 'g')) || []).length;
-  
-  // Update location to match existing position and account for multiple lines
-  if (lineCount > 0) {
-    return {
-      ...replacement,
-      loc: {
-        start: existing.loc.start,
-        end: {
-          line: existing.loc.start.line + lineCount,
-          column: 3 // length of delimiter
-        }
-      }
-    } as String;
-  } else {
-    return {
-      ...replacement,
-      loc: {
-        start: existing.loc.start,
-        end: {
-          line: existing.loc.start.line,
-          column: existing.loc.start.column + replacement.raw.length
-        }
-      }
-    } as String;
-  }
-}
-
 //TODO: Add getOffsets function to get all offsets contained in the tree
 export function replace(root: Root, parent: TreeNode, existing: TreeNode, replacement: TreeNode) {
-  
-  // Special handling for String nodes to fix location (formatting is now handled in patch.ts)
-  if (isString(existing) && isString(replacement)) {
-    replacement = fixStringLocation(existing, replacement);
-  }
   
   // Special handling for DateTime nodes to preserve original format by editing replacement values
   if (isDateTime(existing) && isDateTime(replacement)) {

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -24,11 +24,7 @@ import {
   InlineItem,
   isInlineItem,
   Block,
-  isBlock,
-  DateTime,
-  isDateTime,
-  String,
-  isString
+  isBlock
 } from './ast';
 import { Span, getSpan, clonePosition } from './location';
 import { last, isMultilineString } from './utils';
@@ -38,10 +34,6 @@ import traverse from './traverse';
 // The purpose of this file is to provide a way to modify the AST
 ////////////////////////////////////////
 
-import { DateFormatHelper } from './date-format';
-
-// Create a shorter alias for convenience
-const dateFormatHelper = DateFormatHelper;
 
 // Root node of the AST
 export type Root = Document | TreeNode;
@@ -70,26 +62,6 @@ const getExitOffsets = (root: Root) => {
 
 //TODO: Add getOffsets function to get all offsets contained in the tree
 export function replace(root: Root, parent: TreeNode, existing: TreeNode, replacement: TreeNode) {
-  
-  // Special handling for DateTime nodes to preserve original format by editing replacement values
-  if (isDateTime(existing) && isDateTime(replacement)) {
-    // Analyze the original raw format and create a properly formatted replacement
-    const originalRaw = existing.raw;
-    const newValue = replacement.value;
-    
-    // Create a new date with the original format preserved
-    const formattedDate = dateFormatHelper.createDateWithOriginalFormat(newValue, originalRaw);
-    
-    // Update the replacement with the properly formatted date
-    replacement.value = formattedDate;
-    replacement.raw = formattedDate.toISOString();
-    
-    // Adjust the location information to match the new raw length
-    const lengthDiff = replacement.raw.length - originalRaw.length;
-    if (lengthDiff !== 0) {
-      replacement.loc.end.column = replacement.loc.start.column + replacement.raw.length;
-    }
-  }
   
   // First, replace existing node
   // (by index for items, item, or key/value)

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -33,7 +33,6 @@ import {
 import { Span, getSpan, clonePosition } from './location';
 import { last, isMultilineString } from './utils';
 import traverse from './traverse';
-import { generateString } from './generate';
 
 ////////////////////////////////////////
 // The purpose of this file is to provide a way to modify the AST
@@ -115,11 +114,9 @@ export function fixStringLocation(existing: String, replacement: String): String
 //TODO: Add getOffsets function to get all offsets contained in the tree
 export function replace(root: Root, parent: TreeNode, existing: TreeNode, replacement: TreeNode) {
   
-  // Special handling for String nodes to preserve multiline format by editing replacement values
+  // Special handling for String nodes to fix location (formatting is now handled in patch.ts)
   if (isString(existing) && isString(replacement)) {
-    // Regenerate the replacement with proper escaping based on existing format
-    const escapedReplacement = generateString(replacement.value, existing.raw);
-    replacement = fixStringLocation(existing, escapedReplacement);
+    replacement = fixStringLocation(existing, replacement);
   }
   
   // Special handling for DateTime nodes to preserve original format by editing replacement values


### PR DESCRIPTION
The previous release (v0.5.1) had a warning with regards to `src/generate.ts -> src/writer.ts -> src/generate.ts`.

This PR solves the issue and re-organizes the code with better isolation of concerns. For instance, the `replace` function in `writer.ts` is no longer has to deal with special TOML value types and only handles the replacement of the node in the AST. We now handle the value-type specific formatting issues in `preserveFormatting` directly at the patching logic level (`patch.ts`).