### PR TITLE
refactor: remove circular reference between TomlFormat and generate.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Remove circular dependency between `toml-format` and `generate` modules ([#118](https://github.com/DecimalTurn/toml-patch/pull/118))
+
 ## [1.0.2] - 2026-02-14
 
 ## [1.0.1] - 2026-02-14

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -20,7 +20,6 @@ import {
 } from './ast';
 import { zero, cloneLocation, clonePosition } from './location';
 import { LocalDate } from './parse-toml';
-import { TomlFormat } from './toml-format';
 import { shiftNode } from './writer';
 import { isMultilineString } from './utils';
 
@@ -270,11 +269,11 @@ export function generateBoolean(value: boolean): Boolean {
   };
 }
 
-export function generateDateTime(value: Date, format: TomlFormat): DateTime {
+export function generateDateTime(value: Date, truncateZeroTimeInDates: boolean = false): DateTime {
   
     // Convert Date objects with zero time components to LocalDate
     // so they are serialized as date-only in TOML
-    if (format.truncateZeroTimeInDates &&
+    if (truncateZeroTimeInDates &&
         value.getUTCHours() === 0 &&
         value.getUTCMinutes() === 0 &&
         value.getUTCSeconds() === 0 &&

--- a/src/parse-js.ts
+++ b/src/parse-js.ts
@@ -94,7 +94,7 @@ function walkValue(value: any, format: TomlFormat): Value {
   } else if (isBoolean(value)) {
     return generateBoolean(value);
   } else if (isDate(value)) {
-    return generateDateTime(value, format);
+    return generateDateTime(value, format.truncateZeroTimeInDates);
   } else if (Array.isArray(value)) {
     return walkInlineArray(value, format);
   } else {


### PR DESCRIPTION
This PR simplifies the handling of the `truncateZeroTimeInDates` option. The changes remove the dependency on the `TomlFormat` type in the `generateDateTime` function and instead directly use a boolean parameter to remove coupling.