### PR TITLE
Fix patching for adding to nested inline tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Patching: Adding keys to nested inline tables (e.g. `config = { server = { host = "localhost" } }`) now works correctly
+
 ### Changed
 - Remove circular dependency between `toml-format` and `generate` modules ([#118](https://github.com/DecimalTurn/toml-patch/pull/118))
 

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -2486,9 +2486,6 @@ test('should preserve single-line inline table when updating (backward compatibi
   expect(patched).toContain('point = { x = 1, y = 2, z = 3 }');
 });
 
-// Bug: adding a key to a nested inline table throws
-// "Unsupported parent type "InlineItem" for insert" because the writer's
-// insert() does not handle InlineItem as a valid parent for inserting children.
 test('should add key to nested inline table', () => {
   const existing = 'config = { server = { host = "localhost" } }\n';
 

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -2485,3 +2485,16 @@ test('should preserve single-line inline table when updating (backward compatibi
   // Should preserve single-line format when possible
   expect(patched).toContain('point = { x = 1, y = 2, z = 3 }');
 });
+
+// Bug: adding a key to a nested inline table throws
+// "Unsupported parent type "InlineItem" for insert" because the writer's
+// insert() does not handle InlineItem as a valid parent for inserting children.
+test('should add key to nested inline table', () => {
+  const existing = 'config = { server = { host = "localhost" } }\n';
+
+  const value = parse(existing);
+  value.config.server.port = 8080;
+
+  const patched = patch(existing, value);
+  expect(patched).toContain('port = 8080');
+});

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -261,6 +261,8 @@ function applyChanges(original: Document, updated: Document, changes: Change[], 
         parent = findParent(original, change.path);
         if (isKeyValue(parent)) {
           parent = parent.value;
+        } else if (isInlineItem(parent) && isKeyValue(parent.item)) {
+          parent = parent.item.value;
         }
       }
 


### PR DESCRIPTION
Updated the `applyChanges` function in `src/patch.ts` to correctly traverse and update nested inline tables.