### PR TITLE
feat: ignore undefined values in stringifying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Stringifying: `undefined` values in objects are now silently ignored, matching `JSON.stringify` behavior ([#148](https://github.com/DecimalTurn/toml-patch/pull/148)).
+- Patching: Setting a key to `undefined` now correctly removes it, including in nested tables and inline tables ([#148](https://github.com/DecimalTurn/toml-patch/pull/148)).
+- Patching: Deleting a key from an inline table nested inside an inline array (e.g. `items = [{ name = "x", color = "y" }]`) now works correctly ([#148](https://github.com/DecimalTurn/toml-patch/pull/148)).
+
 ## [1.0.6] - 2026-04-06
 
 ### Fixed
-- Patching: Support patching multiline inline tables.
-- Respect `inlineTableStart` inside Table Arrays (ie. Array of Tables)
+- Patching: Support patching multiline inline tables ([#127](https://github.com/DecimalTurn/toml-patch/pull/127)).
+- Styling: Respect `inlineTableStart` inside Table Arrays (ie. Array of Tables) ([#144](https://github.com/DecimalTurn/toml-patch/pull/144)).
 
 ## [1.0.5] - 2026-03-17
 

--- a/src/__tests__/parse-js.test.ts
+++ b/src/__tests__/parse-js.test.ts
@@ -300,6 +300,14 @@ describe('undefined handling', () => {
       ` + '\n');
   });
 
+  test('should ignore a key whose toJSON() returns undefined', () => {
+    const result = toTOML(parseJS({ a: 'hello', b: { toJSON: () => undefined }, c: 42 }).items, TomlFormat.default());
+    expect(result).toEqual(dedent`
+      a = "hello"
+      c = 42
+      ` + '\n');
+  });
+
   test('should still throw for null values in top-level object', () => {
     expect(() => parseJS({ a: null })).toThrow('"null" values are not supported');
   });

--- a/src/__tests__/parse-js.test.ts
+++ b/src/__tests__/parse-js.test.ts
@@ -275,3 +275,40 @@ test('simple JS Parsing with table', () => {
 
   expect(serialized).toEqual(expectedOutput);
 });
+
+describe('undefined handling', () => {
+  test('should ignore undefined values in top-level object', () => {
+    const result = toTOML(parseJS({ a: 'hello', b: undefined, c: 42 }).items, TomlFormat.default());
+    expect(result).toEqual(dedent`
+      a = "hello"
+      c = 42
+      ` + '\n');
+  });
+
+  test('should ignore undefined values in table', () => {
+    const result = toTOML(parseJS({ owner: { name: 'Alice', nickname: undefined } }).items, TomlFormat.default());
+    expect(result).toEqual(dedent`
+      [owner]
+      name = "Alice"
+      ` + '\n');
+  });
+
+  test('should treat object with only undefined values as empty table', () => {
+    const result = toTOML(parseJS({ a: { b: undefined } }).items, TomlFormat.default());
+    expect(result).toEqual(dedent`
+      [a]
+      ` + '\n');
+  });
+
+  test('should still throw for null values in top-level object', () => {
+    expect(() => parseJS({ a: null })).toThrow('"null" values are not supported');
+  });
+
+  test('should still throw for undefined values inside an array', () => {
+    expect(() => parseJS({ a: [1, undefined, 3] })).toThrow('"undefined" values are not supported inside arrays');
+  });
+
+  test('should still throw for null values inside an array', () => {
+    expect(() => parseJS({ a: [1, null, 3] })).toThrow('"null" values are not supported');
+  });
+});

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -3422,15 +3422,33 @@ describe('undefined handling in patch', () => {
       ` + '\n');
   });
 
-  // An inline array of objects where one object has an undefined key currently
-  // throws in patch() due to a pre-existing bug in the patch engine when
-  // removing keys from objects nested inside inline arrays.
-  test('should throw when patching an inline array of objects where one has an undefined key (known limitation)', () => {
+  // Removing a key from an inline table (object) inside an inline array (e.g. deleting a property
+  // directly without undefined). This is the minimal repro for the bug that was
+  // previously triggered via undefined: the parent at path ["items", 0] was an
+  // InlineItem wrapping an InlineTable, and patch.ts wasn't unwrapping that case.
+  test('should remove a key from an object inside an inline array', () => {
     const existing = dedent`
       items = [ { name = "Hammer", color = "red" }, { name = "Nail", color = "gray" } ]
       ` + '\n';
 
-    expect(() => patch(existing, { items: [{ name: 'Hammer', color: undefined }, { name: 'Nail', color: 'gray' }] })).toThrow();
+    const obj = parse(existing);
+    delete obj.items[0].color;
+
+    expect(patch(existing, obj)).toEqual(dedent`
+      items = [ { name = "Hammer" }, { name = "Nail", color = "gray" } ]
+      ` + '\n');
+  });
+
+  // An inline array of objects where one object has an undefined key should now
+  // work correctly after the InlineItem-wrapping-InlineTable fix.
+  test('should silently drop an undefined key from an object inside an inline array', () => {
+    const existing = dedent`
+      items = [ { name = "Hammer", color = "red" }, { name = "Nail", color = "gray" } ]
+      ` + '\n';
+
+    expect(patch(existing, { items: [{ name: 'Hammer', color: undefined }, { name: 'Nail', color: 'gray' }] })).toEqual(dedent`
+      items = [ { name = "Hammer" }, { name = "Nail", color = "gray" } ]
+      ` + '\n');
   });
 
   test('should throw when patching with undefined inside an array in an inline table', () => {

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -3422,10 +3422,10 @@ describe('undefined handling in patch', () => {
       ` + '\n');
   });
 
-  // A table array element is technically "undefined inside a JS array", but it
+  // A table array element is technically "inside a JS array", but it
   // represents a TOML [[table-array]] entry rather than an inline array element.
   // The library currently throws in this case (same as inline arrays). The
-  // idiomatic way to remove a table array element is via splice().
+  // The current way to remove a table array element is via splice().
   test('should throw when a table array element is set to undefined (use splice to remove instead)', () => {
     const existing = dedent`
       [[products]]
@@ -3449,6 +3449,8 @@ describe('undefined handling in patch', () => {
     );
   });
 
+  // This is just to illustrate the intended way to remove a table array element, 
+  // since setting to undefined is not supported. 
   test('should remove a table array element via splice', () => {
     const existing = dedent`
       [[products]]

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -3398,6 +3398,30 @@ describe('undefined handling in patch', () => {
     );
   });
 
+  test('should throw when patching with undefined inside an array in an inline table', () => {
+    const existing = dedent`
+      config = { ports = [ 8001, 8002, 8003 ] }
+      ` + '\n';
+
+    expect(() => patch(existing, { config: { ports: [8001, undefined, 8003] } })).toThrow(
+      '"undefined" values are not supported inside arrays'
+    );
+  });
+
+  test('should throw when patching with undefined inside an array in a regular table', () => {
+    const existing = dedent`
+      [database]
+      ports = [ 8001, 8002, 8003 ]
+      ` + '\n';
+
+    const obj = parse(existing);
+    obj.database.ports = [8001, undefined, 8003];
+
+    expect(() => patch(existing, obj)).toThrow(
+      '"undefined" values are not supported inside arrays'
+    );
+  });
+
   test('should handle move-like scenario: remove key from one table, add to another', () => {
     const existing = dedent`
       [alpha]

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -3302,3 +3302,73 @@ describe('TOML v1.1 multiline inline tables - fixture (multiline-inline-table.to
       ` + '\n');
   });
 });
+
+describe('undefined handling in patch', () => {
+  test('should remove a key from a table when its value is set to undefined', () => {
+    const existing = dedent`
+      [owner]
+      name = "Tom Preston-Werner"
+      organization = "GitHub"
+      bio = "Developer"
+      ` + '\n';
+
+    const obj = parse(existing);
+    obj.owner.organization = undefined;
+
+    expect(patch(existing, obj)).toEqual(dedent`
+      [owner]
+      name = "Tom Preston-Werner"
+      bio = "Developer"
+      ` + '\n');
+  });
+
+  test('should remove a top-level key when its value is set to undefined', () => {
+    const existing = dedent`
+      title = "TOML Example"
+      debug = true
+      version = "1.0.0"
+      ` + '\n';
+
+    const obj = parse(existing);
+    obj.debug = undefined;
+
+    expect(patch(existing, obj)).toEqual(dedent`
+      title = "TOML Example"
+      version = "1.0.0"
+      ` + '\n');
+  });
+
+  test('should throw when patching with undefined inside an array', () => {
+    const existing = dedent`
+      ports = [ 8001, 8002, 8003 ]
+      ` + '\n';
+
+    expect(() => patch(existing, { ports: [8001, undefined, 8003] })).toThrow(
+      '"undefined" values are not supported inside arrays'
+    );
+  });
+
+  test('should handle move-like scenario: remove key from one table, add to another', () => {
+    const existing = dedent`
+      [alpha]
+      color = "red"
+      name = "Alpha"
+
+      [beta]
+      name = "Beta"
+      ` + '\n';
+
+    const obj = parse(existing);
+    obj.alpha.color = undefined;
+    obj.beta.color = 'red';
+
+    expect(patch(existing, obj)).toEqual(dedent`
+      [alpha]
+      name = "Alpha"
+
+      [beta]
+      name = "Beta"
+      color = "red"
+      ` + '\n');
+  });
+});

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -3398,6 +3398,41 @@ describe('undefined handling in patch', () => {
     );
   });
 
+  test('should not throw when an array contains objects with undefined keys', () => {
+    const existing = dedent`
+      [[products]]
+      name = "Hammer"
+      color = "red"
+
+      [[products]]
+      name = "Nail"
+      color = "gray"
+      ` + '\n';
+
+    const obj = parse(existing);
+    obj.products[0].color = undefined;
+
+    expect(patch(existing, obj)).toEqual(dedent`
+      [[products]]
+      name = "Hammer"
+
+      [[products]]
+      name = "Nail"
+      color = "gray"
+      ` + '\n');
+  });
+
+  // An inline array of objects where one object has an undefined key currently
+  // throws in patch() due to a pre-existing bug in the patch engine when
+  // removing keys from objects nested inside inline arrays.
+  test('should throw when patching an inline array of objects where one has an undefined key (known limitation)', () => {
+    const existing = dedent`
+      items = [ { name = "Hammer", color = "red" }, { name = "Nail", color = "gray" } ]
+      ` + '\n';
+
+    expect(() => patch(existing, { items: [{ name: 'Hammer', color: undefined }, { name: 'Nail', color: 'gray' }] })).toThrow();
+  });
+
   test('should throw when patching with undefined inside an array in an inline table', () => {
     const existing = dedent`
       config = { ports = [ 8001, 8002, 8003 ] }

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -3421,4 +3421,60 @@ describe('undefined handling in patch', () => {
       color = "red"
       ` + '\n');
   });
+
+  // A table array element is technically "undefined inside a JS array", but it
+  // represents a TOML [[table-array]] entry rather than an inline array element.
+  // The library currently throws in this case (same as inline arrays). The
+  // idiomatic way to remove a table array element is via splice().
+  test('should throw when a table array element is set to undefined (use splice to remove instead)', () => {
+    const existing = dedent`
+      [[products]]
+      name = "Hammer"
+      sku = 738594937
+
+      [[products]]
+      name = "Nail"
+      sku = 284758393
+
+      [[products]]
+      name = "Screwdriver"
+      sku = 123456
+      ` + '\n';
+
+    const obj = parse(existing);
+    obj.products[1] = undefined;
+
+    expect(() => patch(existing, obj)).toThrow(
+      '"undefined" values are not supported inside arrays'
+    );
+  });
+
+  test('should remove a table array element via splice', () => {
+    const existing = dedent`
+      [[products]]
+      name = "Hammer"
+      sku = 738594937
+
+      [[products]]
+      name = "Nail"
+      sku = 284758393
+
+      [[products]]
+      name = "Screwdriver"
+      sku = 123456
+      ` + '\n';
+
+    const obj = parse(existing);
+    obj.products.splice(1, 1);
+
+    expect(patch(existing, obj)).toEqual(dedent`
+      [[products]]
+      name = "Hammer"
+      sku = 738594937
+
+      [[products]]
+      name = "Screwdriver"
+      sku = 123456
+      ` + '\n');
+  });
 });

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -3338,6 +3338,56 @@ describe('undefined handling in patch', () => {
       ` + '\n');
   });
 
+  test('should remove a key from an inline table when its value is set to undefined', () => {
+    const existing = dedent`
+      count = { a = 1, b = 2, c = 3 }
+      ` + '\n';
+
+    const obj = parse(existing);
+    obj.count.b = undefined;
+
+    expect(patch(existing, obj)).toEqual(dedent`
+      count = { a = 1, c = 3 }
+      ` + '\n');
+  });
+
+  test('should remove an entire table section when set to undefined', () => {
+    const existing = dedent`
+      [owner]
+      name = "Tom"
+      org = "GitHub"
+
+      [database]
+      server = "localhost"
+      ` + '\n';
+
+    const obj = parse(existing);
+    obj.owner = undefined;
+
+    expect(patch(existing, obj)).toEqual('\n' + dedent`
+      [database]
+      server = "localhost"
+      ` + '\n');
+  });
+
+  test('should leave an empty table header when its only key is set to undefined', () => {
+    const existing = dedent`
+      title = "hello"
+
+      [owner]
+      name = "Tom"
+      ` + '\n';
+
+    const obj = parse(existing);
+    obj.owner.name = undefined;
+
+    expect(patch(existing, obj)).toEqual(dedent`
+      title = "hello"
+
+      [owner]
+      ` + '\n');
+  });
+
   test('should throw when patching with undefined inside an array', () => {
     const existing = dedent`
       ports = [ 8001, 8002, 8003 ]

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -3439,6 +3439,63 @@ describe('undefined handling in patch', () => {
       ` + '\n');
   });
 
+  // Deeper nesting: inline array → inline tables → inline array → inline tables.
+  // Removing a key from an inline table at depth 4.
+  test('should remove a key from a deeply nested inline table (array → objects → array → objects)', () => {
+    const existing = dedent`
+      items = [ { name = "Hammer", tags = [ { key = "material", value = "steel" }, { key = "color", value = "red" } ] }, { name = "Nail", tags = [ { key = "color", value = "gray" } ] } ]
+      ` + '\n';
+
+    const obj = parse(existing);
+    delete obj.items[0].tags[0].value;
+
+    expect(patch(existing, obj)).toEqual(dedent`
+      items = [ { name = "Hammer", tags = [ { key = "material" }, { key = "color", value = "red" } ] }, { name = "Nail", tags = [ { key = "color", value = "gray" } ] } ]
+      ` + '\n');
+  });
+
+  // Same deep nesting but with TOML v1.1 multiline inline arrays and tables.
+  test('should remove a key from a deeply nested inline table with multiline formatting (TOML v1.1)', () => {
+    const existing = dedent`
+      items = [
+        {
+          name = "Hammer",
+          tags = [
+            { key = "material", value = "steel" },
+            { key = "color", value = "red" }
+          ]
+        },
+        {
+          name = "Nail",
+          tags = [
+            { key = "color", value = "gray" }
+          ]
+        }
+      ]
+      ` + '\n';
+
+    const obj = parse(existing);
+    delete obj.items[0].tags[0].value;
+
+    expect(patch(existing, obj)).toEqual(dedent`
+      items = [
+        {
+          name = "Hammer",
+          tags = [
+            { key = "material" },
+            { key = "color", value = "red" }
+          ]
+        },
+        {
+          name = "Nail",
+          tags = [
+            { key = "color", value = "gray" }
+          ]
+        }
+      ]
+      ` + '\n');
+  });
+
   // An inline array of objects where one object has an undefined key should now
   // work correctly after the InlineItem-wrapping-InlineTable fix.
   test('should silently drop an undefined key from an object inside an inline array', () => {

--- a/src/parse-js.ts
+++ b/src/parse-js.ts
@@ -43,13 +43,17 @@ export default function parseJS(value: any, format: TomlFormat = TomlFormat.defa
 
 function* walkObject(object: any, format: TomlFormat): IterableIterator<KeyValue> {
   for (const key of Object.keys(object)) {
+    if (object[key] === undefined) continue;
     yield generateKeyValue([key], walkValue(object[key], format));
   }
 }
 
 function walkValue(value: any, format: TomlFormat): Value {
-  if (value == null) {
-    throw new Error('"null" and "undefined" values are not supported');
+  if (value === null) {
+    throw new Error('"null" values are not supported');
+  }
+  if (value === undefined) {
+    throw new Error('"undefined" values are not supported inside arrays');
   }
 
   if (isString(value)) {

--- a/src/parse-js.ts
+++ b/src/parse-js.ts
@@ -43,8 +43,9 @@ export default function parseJS(value: any, format: TomlFormat = TomlFormat.defa
 
 function* walkObject(object: any, format: TomlFormat): IterableIterator<KeyValue> {
   for (const key of Object.keys(object)) {
-    if (object[key] === undefined) continue;
-    const value = toJSON(object[key]);
+    const rawValue = object[key];
+    if (rawValue === undefined) continue;
+    const value = toJSON(rawValue);
     if (value === undefined) continue;
     yield generateKeyValue([key], walkValue(value, format));
   }

--- a/src/parse-js.ts
+++ b/src/parse-js.ts
@@ -44,7 +44,9 @@ export default function parseJS(value: any, format: TomlFormat = TomlFormat.defa
 function* walkObject(object: any, format: TomlFormat): IterableIterator<KeyValue> {
   for (const key of Object.keys(object)) {
     if (object[key] === undefined) continue;
-    yield generateKeyValue([key], walkValue(object[key], format));
+    const value = toJSON(object[key]);
+    if (value === undefined) continue;
+    yield generateKeyValue([key], walkValue(value, format));
   }
 }
 

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -88,11 +88,9 @@ export function patchAst(existing_ast:AST, updated: any, format: TomlFormat): { 
   const diffing_fmt = resolveTomlFormat({...format, inlineTableStart: undefined}, format);
   const updated_document = parseJS(updated, diffing_fmt);
 
-  // Diff against the JS representation of the generated document rather than
+  // Diff against the JS representation rather than
   // the raw `updated` value, so that any undefined keys (which parseJS already
-  // stripped) are consistently absent from both sides of the diff. Using the
-  // raw object would cause undefined-valued keys to produce spurious Edit ops
-  // that the patch engine cannot resolve.
+  // stripped) are consistently absent from both sides of the diff. 
   const updated_js = toJS(updated_document.items);
   const changes = reorder(diff(existing_js, updated_js));
 

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -87,8 +87,14 @@ export function patchAst(existing_ast:AST, updated: any, format: TomlFormat): { 
   // Therefore, we create a modified format for generating the updated document used for diffing.
   const diffing_fmt = resolveTomlFormat({...format, inlineTableStart: undefined}, format);
   const updated_document = parseJS(updated, diffing_fmt);
-  
-  const changes = reorder(diff(existing_js, updated));
+
+  // Diff against the JS representation of the generated document rather than
+  // the raw `updated` value, so that any undefined keys (which parseJS already
+  // stripped) are consistently absent from both sides of the diff. Using the
+  // raw object would cause undefined-valued keys to produce spurious Edit ops
+  // that the patch engine cannot resolve.
+  const updated_js = toJS(updated_document.items);
+  const changes = reorder(diff(existing_js, updated_js));
 
   if (changes.length === 0) {
     return {

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -412,6 +412,12 @@ function applyChanges(original: Document, updated: Document, changes: Change[], 
         if (isInlineItem(parent) && isKeyValue((parent as InlineItem).item)) {
           parent = ((parent as InlineItem).item as KeyValue).value;
         }
+        // When the parent is an InlineItem wrapping an InlineTable (an object inside an inline
+        // array, e.g. `items = [{ name = "x", color = "y" }]`), unwrap to the InlineTable so
+        // `remove` receives a node type that `hasItems` accepts.
+        if (isInlineItem(parent) && isInlineTable((parent as InlineItem).item)) {
+          parent = (parent as InlineItem).item;
+        }
         // The logical (JS-object) parent may differ from the AST parent.
         // For example, [server.tls] lives in document.items, not [server].items.
         // Fall back to the document root when the parent doesn't contain the node.


### PR DESCRIPTION
Closes #132

The stringifying fix itself is simple: skip any key whose value is `undefined`.
(we also skip keys whose value is an object with a `toJSON()` method that returns `undefined`).

```js
stringify({ name: "Alice", age: undefined });
// name = "Alice"   ← age silently dropped, no error
```

The trickier part was making sure it doesn't break the **patching** side (this is `toml-patch` after all!). When patching, the library diffs the existing JS object against the updated one to figure out what changed. To make things work, I had to make sure we have a "cleaned-up" representation on both side of the diff to make sure `undefined` behaves like a deletion and not an edit.

As dicussed in the issue, we still throw when there's a `undefined` inside a JS array. This can be unintuitive in the case of Table Arrays (array of tables), because setting an entire `[table]` section to `undefined` works just like a deletion:

```toml
[owner]
name = "Tom"
org = "GitHub"

[database]
server = "localhost"
```

```js
obj.owner = undefined;
patch(toml, obj);
// [database]
// server = "localhost"   ← [owner] section cleanly removed
```

But a `[[table-array]]` is an array of objects, and setting a **whole element** to `undefined` throws:

```toml
[[products]]
name = "Hammer"
sku = 738594937

[[products]]
name = "Nail"
sku = 284758393
```

```js
obj.products[1] = undefined;
patch(toml, obj); // Error: "undefined" values are not supported inside arrays
```

But if you need to make an element of an array disappear from the TOML output, you can still just use splice:

```js
obj.products.splice(1, 1);
patch(toml, obj); // works great
```

In order to handle a `undefined` table array as deletion we would need to know in advance how it will be rendered in TOML as an inline array or a table array. However, this edge case is probably rare enough not to cause real problems in practice, but worth knowing about.
