### PR TITLE
feat: add parse options to TomlDocument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Patching: Editing a multiline basic string that uses a line ending backslash now preserves the original line-break structure and indentation. When the new value cannot be faithfully represented with a line ending backslash (e.g., values with leading or trailing whitespace), the format falls back to a regular multiline basic string to preserve content integrity ([#131]).
-- Parsing: Preserve full integer precision by returning `BigInt` for values outside the JS safe integer range. Fallback to `Number` when integer cannot be parsed as a `BigInt` ([#153]).
+- Parsing: Preserve full integer precision by returning `BigInt` for values outside the JS safe integer range. Fallback to `Number` when integer cannot be parsed as a `BigInt` ([#153] & [#158]).
 - Patching: Fixed mixed line endings bugs ([#131]).
 - Date formatting: Ensure UTC year output is zero-padded to 4 digits for RFC3339 compliance ([#153]).
 - Encoding: Fix encoding issue with DEL control character ([#153] & [#131]).
@@ -202,30 +202,31 @@ This first forked version from [timhall/toml-patch](https://github.com/timhall/t
 - Ensures all latest spec tests from https://github.com/iarna/toml-spec-tests are passing (1880b1a)
 
 
-[#131]: https://github.com/DecimalTurn/toml-patch/pull/131
-[#153]: https://github.com/DecimalTurn/toml-patch/pull/153
-[#148]: https://github.com/DecimalTurn/toml-patch/pull/148
-[#127]: https://github.com/DecimalTurn/toml-patch/pull/127
-[#144]: https://github.com/DecimalTurn/toml-patch/pull/144
-[#118]: https://github.com/DecimalTurn/toml-patch/pull/118
-[#122]: https://github.com/DecimalTurn/toml-patch/pull/122
-[#125]: https://github.com/DecimalTurn/toml-patch/pull/125
-[#106]: https://github.com/DecimalTurn/toml-patch/pull/106
-[#105]: https://github.com/DecimalTurn/toml-patch/pull/105
-[#104]: https://github.com/DecimalTurn/toml-patch/pull/104
-[#100]: https://github.com/DecimalTurn/toml-patch/pull/100
-[#94]: https://github.com/DecimalTurn/toml-patch/pull/95
-[#90]: https://github.com/DecimalTurn/toml-patch/pull/90
-[#87]: https://github.com/DecimalTurn/toml-patch/pull/87
-[#86]: https://github.com/DecimalTurn/toml-patch/pull/86
+[#1]: https://github.com/DecimalTurn/toml-patch/pull/1
+[#2]: https://github.com/DecimalTurn/toml-patch/pull/2
+[#3]: https://github.com/DecimalTurn/toml-patch/pull/3
+[#4]: https://github.com/DecimalTurn/toml-patch/pull/4
+[#53]: https://github.com/DecimalTurn/toml-patch/pull/53
+[#61]: https://github.com/DecimalTurn/toml-patch/pull/61
+[#64]: https://github.com/DecimalTurn/toml-patch/pull/64
 [#66]: https://github.com/DecimalTurn/toml-patch/pull/66
 [#77]: https://github.com/DecimalTurn/toml-patch/pull/77
 [#79]: https://github.com/DecimalTurn/toml-patch/pull/79
 [#82]: https://github.com/DecimalTurn/toml-patch/pull/82
-[#64]: https://github.com/DecimalTurn/toml-patch/pull/64
-[#53]: https://github.com/DecimalTurn/toml-patch/pull/53
-[#61]: https://github.com/DecimalTurn/toml-patch/pull/61
-[#4]: https://github.com/DecimalTurn/toml-patch/pull/4
-[#3]: https://github.com/DecimalTurn/toml-patch/pull/3
-[#1]: https://github.com/DecimalTurn/toml-patch/pull/1
-[#2]: https://github.com/DecimalTurn/toml-patch/pull/2
+[#86]: https://github.com/DecimalTurn/toml-patch/pull/86
+[#87]: https://github.com/DecimalTurn/toml-patch/pull/87
+[#90]: https://github.com/DecimalTurn/toml-patch/pull/90
+[#94]: https://github.com/DecimalTurn/toml-patch/pull/94
+[#100]: https://github.com/DecimalTurn/toml-patch/pull/100
+[#104]: https://github.com/DecimalTurn/toml-patch/pull/104
+[#105]: https://github.com/DecimalTurn/toml-patch/pull/105
+[#106]: https://github.com/DecimalTurn/toml-patch/pull/106
+[#118]: https://github.com/DecimalTurn/toml-patch/pull/118
+[#122]: https://github.com/DecimalTurn/toml-patch/pull/122
+[#125]: https://github.com/DecimalTurn/toml-patch/pull/125
+[#127]: https://github.com/DecimalTurn/toml-patch/pull/127
+[#131]: https://github.com/DecimalTurn/toml-patch/pull/131
+[#144]: https://github.com/DecimalTurn/toml-patch/pull/144
+[#148]: https://github.com/DecimalTurn/toml-patch/pull/148
+[#153]: https://github.com/DecimalTurn/toml-patch/pull/153
+[#158]: https://github.com/DecimalTurn/toml-patch/pull/158

--- a/README.md
+++ b/README.md
@@ -235,13 +235,18 @@ The `TomlDocument` class provides a stateful interface for working with TOML doc
 #### Constructor
 
 ```typescript
-new TomlDocument(tomlSource: string | Uint8Array)
+new TomlDocument(tomlSource: string | Uint8Array, options?: ParseOptions)
 ```
 
 Initializes the TomlDocument with TOML source, parsing it into an internal representation (AST). When bytes are provided they are decoded as UTF-8 in fatal mode, rejecting invalid sequences before parsing.
 
 **Parameters:**
 - `tomlSource: string | Uint8Array` - The TOML source to parse
+- `options?: ParseOptions` - Optional parse options
+  - `integersAsBigInt?: 'asNeeded' | true | false` — Controls how TOML integers are represented in `toJsObject`:
+    - `'asNeeded'` *(default)* — integers within the JS safe-integer range are `number`; larger values are `bigint` to preserve precision
+    - `true` — all integers are returned as `bigint`
+    - `false` — all integers are returned as `number` (large values lose precision)
 
 ##### Basic Usage Example
 

--- a/src/__tests__/toml-document.test.ts
+++ b/src/__tests__/toml-document.test.ts
@@ -21,6 +21,21 @@ describe('TomlDocument', () => {
     expect(doc.toJsObject).toEqual(simpleObj);
   });
 
+  it('supports parse options in constructor (integersAsBigInt: false)', () => {
+    const doc = new TomlDocument('x = 9223372036854775807\n', { integersAsBigInt: false });
+    const parsed = doc.toJsObject;
+
+    expect(typeof parsed.x).toBe('number');
+  });
+
+  it('supports parse options in constructor (integersAsBigInt: true)', () => {
+    const doc = new TomlDocument('x = 42\n', { integersAsBigInt: true });
+    const parsed = doc.toJsObject;
+
+    expect(typeof parsed.x).toBe('bigint');
+    expect(parsed.x).toBe(BigInt(42));
+  });
+
   it('returns the original TOML string', () => {
     const doc = new TomlDocument(simpleToml);
     expect(doc.toTomlString).toBe(simpleToml);

--- a/src/toml-document.ts
+++ b/src/toml-document.ts
@@ -5,6 +5,7 @@ import { Block } from './ast';
 import { patchAst } from './patch';
 import { detectNewline, resolveTomlFormat } from './toml-format';
 import { truncateAst } from './truncate';
+import type { ParseOptions, IntegersAsBigInt } from './parse-options';
 
 /**
  * TomlDocument encapsulates a TOML AST and provides methods to interact with it.
@@ -13,6 +14,7 @@ export class TomlDocument {
   private _ast: Block[];
   private _currentTomlString: string;
   private _format: TomlFormat;
+  private _integersAsBigInt: IntegersAsBigInt;
 
   /**
    * Initializes the TomlDocument with TOML source, parsing it into an AST.
@@ -21,14 +23,17 @@ export class TomlDocument {
    * This rejects invalid UTF-8 sequences before parsing.
    *
    * @param tomlSource - The TOML source to parse (string or raw UTF-8 bytes)
+   * @param options - Optional parse options
+   * @param options.integersAsBigInt - Controls bigint vs number for TOML integers
    */
-  constructor(tomlSource: string | Uint8Array) {
+  constructor(tomlSource: string | Uint8Array, options?: ParseOptions) {
     const tomlString = typeof tomlSource === 'string'
       ? tomlSource
       : new TextDecoder('utf-8', { fatal: true }).decode(tomlSource);
 
     this._currentTomlString = tomlString;
     this._ast = Array.from(parseTOML(tomlString));
+    this._integersAsBigInt = options?.integersAsBigInt ?? 'asNeeded';
     // Auto-detect formatting preferences from the original TOML string
     this._format = TomlFormat.autoDetectFormat(tomlString);
   }
@@ -41,7 +46,7 @@ export class TomlDocument {
    * Returns the JavaScript object representation of the TOML document.
    */
   get toJsObject(): any {
-    const jsObject = toJS(this._ast, this._currentTomlString);
+    const jsObject = toJS(this._ast, this._currentTomlString, this._integersAsBigInt);
     // Convert custom date classes to regular JavaScript Date objects
     return convertCustomDateClasses(jsObject);
   }


### PR DESCRIPTION
This pull request adds support for parse options in the `TomlDocument` constructor, allowing users to control how TOML integers are represented in the resulting JavaScript object. 