### PR TITLE
fix: apply multiline inline table patching fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Patching: Ensure deleting last key of inline-table is done cleanly ([#164]).
+- Patching: Preserving trailing comments on inline tables when deleting keys ([#164]).
+- Patching: Support nested multiline inline-table patching inside arrays ([#164]).
+
 ## [1.1.1] - 2026-04-20
 
 ### Fixed
@@ -236,3 +242,4 @@ This first forked version from [timhall/toml-patch](https://github.com/timhall/t
 [#148]: https://github.com/DecimalTurn/toml-patch/pull/148
 [#153]: https://github.com/DecimalTurn/toml-patch/pull/153
 [#158]: https://github.com/DecimalTurn/toml-patch/pull/158
+[#164]: https://github.com/DecimalTurn/toml-patch/pull/164

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -63,6 +63,23 @@ test('should remove key-value with inline comment from table', () => {
   `);
 });
 
+test('should preserve trailing comment on single-line inline table when deleting a key', () => {
+  // Regression for: the orphaned-comment cleanup in writer.ts must NOT fire for
+  // single-line inline tables. For a single-line table the parser does not extract
+  // comments into root.items — any trailing `# comment` remains a root-level item
+  // associated with the KV line, not the inline table. Incorrectly dropping it by
+  // matching `commentLine === removedLine` would silently delete user comments.
+  const input = dedent`
+    t = { a = 1, b = 2 } # keep this comment
+  `;
+  const value = parse(input);
+  delete value.t.a;
+
+  expect(patch(input, value)).toEqual(dedent`
+    t = { b = 2 } # keep this comment
+  `);
+});
+
 test('should remove element from inline array', () => {
   const value = parse(example);
   value.database.ports.splice(1, 1);

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -46,6 +46,23 @@ test('should remove key-value from table', () => {
   expect(patch(example, value)).toMatchSnapshot();
 });
 
+test('should remove key-value with inline comment from table', () => {
+  const input = dedent`
+    [database]
+    server = "192.168.1.1"
+    enabled = true # enable this feature
+    ports = [8001, 8001, 8002]
+  `;
+  const value = parse(input);
+  delete value.database.enabled;
+
+  expect(patch(input, value)).toEqual(dedent`
+    [database]
+    server = "192.168.1.1"
+    ports = [8001, 8001, 8002]
+  `);
+});
+
 test('should remove element from inline array', () => {
   const value = parse(example);
   value.database.ports.splice(1, 1);

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -3141,6 +3141,24 @@ describe('TOML v1.1 multiline inline tables - edit operations (newline.toml spec
       ` + '\n');
   });
 
+
+  test('should delete the only key from a multiline inline table and leave it empty', () => {
+    const existing = dedent`
+      tbl-1 = {
+              only = 1,
+      }
+      ` + '\n';
+
+    const value = parse(existing);
+    delete value['tbl-1'].only;
+    const patched = patch(existing, value);
+
+    expect(patched).toEqual(dedent`
+      tbl-1 = {
+      }
+      ` + '\n');
+  });
+
   test('should delete a nested inline table key leaving empty nested table', () => {
     const existing = dedent`
       tbl-1 = {
@@ -3161,7 +3179,7 @@ describe('TOML v1.1 multiline inline tables - edit operations (newline.toml spec
       }
       ` + '\n');
   });
-
+  
   test('should delete an entire nested inline table entry', () => {
     const existing = dedent`
       tbl-1 = {
@@ -3507,23 +3525,6 @@ describe('TOML v1.1 multiline inline tables with comments (newline-comment.toml 
       tbl-1 = {#comment
               #comment
       }#comment
-      ` + '\n');
-  });
-
-  test('should delete the only key from a multiline inline table without comments', () => {
-    const existing = dedent`
-      tbl-1 = {
-              only = 1,
-      }
-      ` + '\n';
-
-    const value = parse(existing);
-    delete value['tbl-1'].only;
-    const patched = patch(existing, value);
-
-    expect(patched).toEqual(dedent`
-      tbl-1 = {
-      }
       ` + '\n');
   });
 

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -3328,6 +3328,29 @@ describe('TOML v1.1 multiline inline tables - edit operations (newline.toml spec
 
 describe('TOML v1.1 multiline inline tables - trailing comma preservation', () => {
 
+  test('should preserve multiline inline table formatting when replacing the whole value', () => {
+    const existing = dedent`
+      t = {
+          a = 1,
+          b = 2,
+      }
+      ` + '\n';
+
+    const patched = patch(existing, {
+      t: {
+        b: 20,
+        c: 3,
+      },
+    });
+
+    expect(patched).toEqual(dedent`
+      t = {
+          b = 20,
+          c = 3,
+      }
+      ` + '\n');
+  });
+
   test('should preserve trailing comma on last item when editing last item', () => {
     const existing = dedent`
       t = {
@@ -3448,6 +3471,25 @@ describe('TOML v1.1 multiline inline tables with comments (newline-comment.toml 
     expect(patched).toEqual(dedent`
       tbl-1 = {#comment
               b = 2,#comment
+      }#comment
+      ` + '\n');
+  });
+
+  test('should delete the only key from a commented multiline inline table and preserve surrounding comments', () => {
+    const existing = dedent`
+      tbl-1 = {#comment
+              only = 1,#comment
+              #comment
+      }#comment
+      ` + '\n';
+
+    const value = parse(existing);
+    delete value['tbl-1'].only;
+    const patched = patch(existing, value);
+
+    expect(patched).toEqual(dedent`
+      tbl-1 = {#comment
+              #comment
       }#comment
       ` + '\n');
   });
@@ -3830,6 +3872,37 @@ describe('undefined handling in patch', () => {
           tags = [
             { key = "color", value = "gray" }
           ]
+        }
+      ]
+      ` + '\n');
+  });
+
+  test('should preserve multiline inline table formatting when replacing an object inside a multiline inline array', () => {
+    const existing = dedent`
+      items = [
+        {
+          name = "Hammer",
+          color = "red",
+        },
+        {
+          name = "Nail",
+          color = "gray",
+        }
+      ]
+      ` + '\n';
+
+    const obj = parse(existing);
+    obj.items[0] = { name: 'Hammer', sku: 'H1' };
+
+    expect(patch(existing, obj)).toEqual(dedent`
+      items = [
+        {
+          name = "Hammer",
+          sku = "H1",
+        },
+        {
+          name = "Nail",
+          color = "gray",
         }
       ]
       ` + '\n');

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -3157,7 +3157,6 @@ describe('TOML v1.1 multiline inline tables - edit operations (newline.toml spec
     expect(patched).toEqual(dedent`
       tbl-1 = {
               tbl = {
-
               }
       }
       ` + '\n');
@@ -3508,6 +3507,23 @@ describe('TOML v1.1 multiline inline tables with comments (newline-comment.toml 
       tbl-1 = {#comment
               #comment
       }#comment
+      ` + '\n');
+  });
+
+  test('should delete the only key from a multiline inline table without comments', () => {
+    const existing = dedent`
+      tbl-1 = {
+              only = 1,
+      }
+      ` + '\n';
+
+    const value = parse(existing);
+    delete value['tbl-1'].only;
+    const patched = patch(existing, value);
+
+    expect(patched).toEqual(dedent`
+      tbl-1 = {
+      }
       ` + '\n');
   });
 

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -269,6 +269,8 @@ function applyChanges(original: Document, updated: Document, changes: Change[], 
           parent = parent.value;
         } else if (isInlineItem(parent) && isKeyValue(parent.item)) {
           parent = parent.item.value;
+        } else if (isInlineItem(parent) && isInlineTable(parent.item)) {
+          parent = parent.item;
         }
       }
 

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -489,17 +489,21 @@ export function remove(root: Root, parent: TreeNode, node: TreeNode) {
     columns: keep_line ? -removed_span.columns : 0
   };
 
-  // If there is nothing left, don't perform any offsets
-  const hasRootInlineTableComments =
-    isInlineTable(parent) &&
-    hasItems(root) &&
-    root !== parent &&
-    (root as WithItems).items.some(item => isComment(item));
+  // If there is nothing left, don't perform any offsets.
+  //
+  // Exception: multiline inline containers (InlineTable / InlineArray whose opening
+  // and closing brackets are on different lines).  For those, `offset.lines` must
+  // stay intact so that `applyWrites` shifts the closing bracket up to close the
+  // gap left by the removed item.  Single-line containers are fine to zero because
+  // the bracket is on the same line as the (now-gone) item.
+  const isMultilineInlineContainer =
+    (isInlineTable(parent) || isInlineArray(parent)) &&
+    parent.loc.end.line > parent.loc.start.line;
 
   if (
     previous === undefined &&
     next === undefined &&
-    !hasRootInlineTableComments
+    !isMultilineInlineContainer
   ) {
     offset.lines = 0;
     offset.columns = 0;

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -490,7 +490,17 @@ export function remove(root: Root, parent: TreeNode, node: TreeNode) {
   };
 
   // If there is nothing left, don't perform any offsets
-  if(previous === undefined && next === undefined) {
+  const hasRootInlineTableComments =
+    isInlineTable(parent) &&
+    hasItems(root) &&
+    root !== parent &&
+    (root as WithItems).items.some(item => isComment(item));
+
+  if (
+    previous === undefined &&
+    next === undefined &&
+    !hasRootInlineTableComments
+  ) {
     offset.lines = 0;
     offset.columns = 0;
   }
@@ -570,7 +580,7 @@ export function remove(root: Root, parent: TreeNode, node: TreeNode) {
   // Fix: for root-level comments that sit before the removed line, pre-shift them in the
   // opposite direction so that the bleedthrough restores them to their original position.
   // Comments on the deleted line are removed from root.items entirely.
-  if (isInlineTable(parent) && offset.lines !== 0 && hasItems(root) && root !== parent) {
+  if (isInlineTable(parent) && hasItems(root) && root !== parent) {
     const removedLine = node.loc.start.line;
     const rootItems = (root as WithItems).items;
     const toRemove: number[] = [];
@@ -582,7 +592,7 @@ export function remove(root: Root, parent: TreeNode, node: TreeNode) {
       if (commentLine === removedLine) {
         // Comment was on the same line as the removed item — drop it.
         toRemove.push(i);
-      } else if (commentLine < removedLine) {
+      } else if (offset.lines !== 0 && commentLine < removedLine) {
         // Comment is before the removed line: pre-compensate so the bleedthrough
         // offset applied during applyWrites leaves it at its original position.
         (item as Comment).loc.start.line -= offset.lines;

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -584,7 +584,12 @@ export function remove(root: Root, parent: TreeNode, node: TreeNode) {
   // Fix: for root-level comments that sit before the removed line, pre-shift them in the
   // opposite direction so that the bleedthrough restores them to their original position.
   // Comments on the deleted line are removed from root.items entirely.
-  if (isInlineTable(parent) && hasItems(root) && root !== parent) {
+  //
+  // Scope: only multiline inline tables. For single-line inline tables the parser does NOT
+  // extract comments into root — any comment after `{ ... }` on the same line stays as a
+  // root-level item but is NOT associated with the inline table's items, so the
+  // `commentLine === removedLine` drop would incorrectly delete it.
+  if (isMultilineInlineContainer && hasItems(root) && root !== parent) {
     const removedLine = node.loc.start.line;
     const rootItems = (root as WithItems).items;
     const toRemove: number[] = [];


### PR DESCRIPTION
This pull request adds and improves support for preserving formatting and comments in TOML v1.1 multiline inline tables, especially when editing or removing keys and objects. It introduces new tests to cover edge cases and refines the logic for handling inline tables and comments during patching and removal operations.

Main fixes:

1) Nested tables with the following structure: inline table > inline array > inline table can be patched:

```toml
      items = [
        {
          name = "Hammer",
          color = "red",
        },
        {
          name = "Nail",
          color = "gray",
        }
      ]
```

2) Full comments preservation when deleting elements.

In regular key-value pairs in regular tables, we expect that if we remove the kvp, it should remove the comment on the same line. However, for inline tables, it's not clear what the expectations should be. For instance, consider the following:

```toml
	demo = {
		a = "test1", b = "test2" # This is a comment
	}
```

Should deleting `b = "test2"` means that we should also remove the comment at the end of the line? What if the comment was for both `a` and `b` and remains valid information after `b` is removed? Due to this ambiguity, we are better off not deleting comments inside inline tables. This PR should ensure that's the case.