### PR TITLE
fix: prevent error during implicit intermediate key removal for dotted table keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Patching: prevent error during implicit intermediate key/table removal for dotted table keys
+
+
 ## [2.0.0] - 2026-05-31
 
 ### Changed

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -4463,3 +4463,87 @@ describe('Root key-value placement', () => {
     ` + '\n');
   });
 });
+
+describe('implicit intermediate key removal (dotted table keys)', () => {
+  test('should remove a section whose key is an implicit parent of a dotted table key', () => {
+    const existing = dedent`
+      [project]
+      name = "test"
+
+      [references.VBIDE]
+      version = "5.3"
+      guid = "{0002E157-0000-0000-C000-000000000046}"
+    ` + '\n';
+
+    const patched = patch(existing, { project: { name: 'test-updated' } });
+
+    expect(patched).toContain('[project]');
+    expect(patched).toContain('name = "test-updated"');
+    expect(patched).not.toContain('[references.VBIDE]');
+    expect(patched).not.toContain('version');
+    expect(patched).not.toContain('guid');
+  });
+
+  test('should remove a deeply nested section when implicit parent key is absent from patch', () => {
+    const existing = dedent`
+      [project]
+      name = "test"
+
+      [x.y.z]
+      value = 42
+    ` + '\n';
+
+    const patched = patch(existing, { project: { name: 'test-updated' } });
+
+    expect(patched).toContain('[project]');
+    expect(patched).toContain('name = "test-updated"');
+    expect(patched).not.toContain('[x.y.z]');
+    expect(patched).not.toContain('value');
+  });
+
+  test('should remove a section whose dotted key matches exactly a missing key path', () => {
+    // Here the table key is ["deeply", "nested"] and the removed key is "deeply".
+    // No CST node has key ["deeply"] alone — it's the implicit parent of ["deeply","nested"].
+    const existing = dedent`
+      [deeply.nested]
+      value = 1
+    ` + '\n';
+
+    const patched = patch(existing, {});
+
+    expect(patched).not.toContain('deeply');
+    expect(patched).not.toContain('nested');
+    expect(patched).not.toContain('value');
+  });
+
+  test('should remove a mix of root KVs and implicit-parent table sections', () => {
+    const existing = dedent`
+      title = "My App"
+      [server]
+      host = "localhost"
+      [references.VBIDE]
+      version = "5.3"
+    ` + '\n';
+
+    const patched = patch(existing, { title: 'My App' });
+
+    expect(patched).toContain('title = "My App"');
+    expect(patched).not.toContain('[server]');
+    expect(patched).not.toContain('[references.VBIDE]');
+  });
+
+  test('should preserve a section when its implicit parent IS provided in the patch', () => {
+    // When the patch explicitly includes the parent key, the section should survive.
+    const existing = dedent`
+      [references.VBIDE]
+      version = "5.3"
+    ` + '\n';
+
+    const patched = patch(existing, {
+      references: { VBIDE: { version: '5.3' } }
+    });
+
+    expect(patched).toContain('[references.VBIDE]');
+    expect(patched).toContain('version = "5.3"');
+  });
+});

--- a/src/__tests__/patch.test.ts
+++ b/src/__tests__/patch.test.ts
@@ -4546,4 +4546,93 @@ describe('implicit intermediate key removal (dotted table keys)', () => {
     expect(patched).toContain('[references.VBIDE]');
     expect(patched).toContain('version = "5.3"');
   });
+
+  test('should remove multiple tables sharing the same implicit parent prefix', () => {
+    // When multiple dotted tables share the same implicit parent, removing that
+    // parent should remove all of them.
+    const existing = dedent`
+      [references.VBIDE]
+      version = "5.3"
+
+      [references.other]
+      value = 42
+    ` + '\n';
+
+    const patched = patch(existing, {});
+
+    expect(patched).not.toContain('[references.VBIDE]');
+    expect(patched).not.toContain('version');
+    expect(patched).not.toContain('[references.other]');
+    expect(patched).not.toContain('value');
+  });
+
+  test('should remove at an intermediate level of a deeply dotted key', () => {
+    // Table key is ["x", "y", "z"]. Removing at path ['x', 'y'] should still
+    // match and remove the table — neither ['x'] nor ['x','y'] has its own node.
+    const existing = dedent`
+      [x.y.z]
+      value = 1
+    ` + '\n';
+
+    const patched = patch(existing, {});
+
+    expect(patched).not.toContain('x');
+    expect(patched).not.toContain('value');
+  });
+
+  test('should remove a table array whose key starts with the implicit parent path', () => {
+    // [[products.variants]] creates a TableArray with key ["products", "variants"].
+    // Removing at path ['products'] should find it via prefix match.
+    const existing = dedent`
+      title = "Catalog"
+
+      [[products.variants]]
+      sku = 123
+    ` + '\n';
+
+    const patched = patch(existing, { title: 'Catalog' });
+
+    expect(patched).toContain('title = "Catalog"');
+    expect(patched).not.toContain('[[products.variants]]');
+    expect(patched).not.toContain('sku');
+  });
+
+  test('should remove table arrays with an implicitly-keyed parent alongside other removals', () => {
+    // Combined scenario: edit a root KV, remove a simple table section, and
+    // remove an implicitly-keyed table array in a single patch.
+    const existing = dedent`
+      title = "original"
+      version = 1
+
+      [server]
+      host = "localhost"
+
+      [[products.variants]]
+      sku = 999
+    ` + '\n';
+
+    const patched = patch(existing, { title: 'updated' });
+
+    expect(patched).toContain('title = "updated"');
+    expect(patched).not.toContain('version');
+    expect(patched).not.toContain('[server]');
+    expect(patched).not.toContain('[[products.variants]]');
+    expect(patched).not.toContain('sku');
+  });
+
+  test('should remove everything via empty patch when both simple and dotted tables exist', () => {
+    const existing = dedent`
+      name = "app"
+      [server]
+      host = "localhost"
+      [references.VBIDE]
+      version = "5.3"
+      [[products.variants]]
+      sku = 123
+    ` + '\n';
+
+    const patched = patch(existing, {});
+
+    expect(patched.trim()).toBe('');
+  });
 });

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -28,7 +28,7 @@ import {
 } from './cst';
 import diff, { Change, isAdd, isEdit, isRemove, isMove, isRename } from './diff';
 import findByPath, { tryFindByPath, findParent } from './find-by-path';
-import { last, isInteger } from './utils';
+import { last, isInteger, arraysEqual } from './utils';
 import { insert, replace, remove, applyWrites } from './writer';
 import { generateInlineItem, generateTable, generateTableArray, generateString } from './generate';
 import { IS_BARE_KEY } from './tokenizer';
@@ -516,8 +516,21 @@ function applyChanges(original: Document, updated: Document, changes: Change[], 
             remove(original, original, entry);
           }
         } else {
-          // Not a table array — let findByPath throw the descriptive error.
-          findByPath(original, change.path);
+          // The path might be an implicit intermediate key — a key that is a
+          // prefix of a dotted table key but has no CST node of its own.
+          // For example, [references.VBIDE] creates a Table with key
+          // ["references", "VBIDE"], so a Remove at path ["references"] has
+          // no exact node match. Find all document-level items whose key
+          // starts with the change path and remove them.
+          const prefixNodes = findDocumentItemsByKeyPrefix(original, change.path);
+          if (prefixNodes.length > 0) {
+            for (const prefixNode of prefixNodes) {
+              remove(original, original, prefixNode);
+            }
+          } else {
+            // Not a table array or implicit key — let findByPath throw the descriptive error.
+            findByPath(original, change.path);
+          }
         }
       } else {
         let parent = findParent(original, change.path);
@@ -699,4 +712,32 @@ function findEnclosingInlineTableRowContext(
       return { container, row: candidate };
     }
   }
+}
+
+/**
+ * Finds all Document-level items whose key path starts with the given prefix.
+ * This handles implicit intermediate keys — keys that are a prefix of a dotted
+ * table key but have no CST node of their own (e.g. path ["references"] when
+ * only ["references", "VBIDE"] exists in the document).
+ */
+function findDocumentItemsByKeyPrefix(
+  document: Document,
+  pathPrefix: Array<string | number>
+): Block[] {
+  const matchingNodes: Block[] = [];
+  for (const item of document.items) {
+    let key: string[] | undefined;
+    if (isKeyValue(item)) {
+      key = item.key.value;
+    } else if (isTable(item)) {
+      key = item.key.item.value;
+    } else if (isTableArray(item)) {
+      key = item.key.item.value;
+    }
+
+    if (key && arraysEqual(key.slice(0, pathPrefix.length), pathPrefix)) {
+      matchingNodes.push(item);
+    }
+  }
+  return matchingNodes;
 }


### PR DESCRIPTION
Before this fix, `patch(existingToml, patchValue)` threw with `Node not found at references` when the TOML had something like `[references.VBIDE]` but the patch value didn't include a `references` key/table at all.

## Why it happened

The TOML parser creates a **single** `Table` CST node with key `["references", "VBIDE"]`
for the header `[references.VBIDE]`. There is **no** separate node for `references` alone —
it's an *implicit intermediate key* — a prefix of a dotted key that doesn't have its own
entry in the CST.

When the diff engine compares the JS objects:

```
before: { project: { … }, references: { VBIDE: { … } } }
after:  { project: { … } }
```

It correctly produces a `Remove` change at path `['references']`. But when `applyChanges`
tries to resolve that path with `findByPath(original, ['references'])`, there is no CST node
with that exact key — only the compound key `["references", "VBIDE"]` — so it throws.

## The fix

**File:** `src/patch.ts`

**What changed:** The `Remove` handler in `applyChanges` gained a new fallback before
the final `throw`. When `tryFindByPath` returns nothing and the path isn't a table array,
a new helper `findDocumentItemsByKeyPrefix` scans the document for all top-level items
(KeyValue, Table, TableArray) whose key path starts with the change path. Every match
is removed from the document.

**Example:** For path `['references']`, it finds the `Table` with key `["references", "VBIDE"]`
and removes it — along with all its child key-values (`version`, `guid`, etc.).

If no items match the prefix either, the original `findByPath` error is still thrown
(so truly invalid paths still produce a descriptive message).
